### PR TITLE
[WIP] Adds reverse lookup support (primary name)

### DIFF
--- a/core/Move.toml
+++ b/core/Move.toml
@@ -9,10 +9,10 @@ aptos_names_funds = "0x78ee3915e67ef5d19fa91d1e05e60ae08751efd12ce58e23fc1109de8
 
 [dependencies.AptosFramework]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-framework'
 
 [dependencies.AptosToken]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-token'

--- a/core/Move.toml
+++ b/core/Move.toml
@@ -9,10 +9,10 @@ aptos_names_funds = "0x78ee3915e67ef5d19fa91d1e05e60ae08751efd12ce58e23fc1109de8
 
 [dependencies.AptosFramework]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'mainnet'
+rev = 'framework-mainnet'
 subdir = 'aptos-move/framework/aptos-framework'
 
 [dependencies.AptosToken]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'mainnet'
+rev = 'framework-mainnet'
 subdir = 'aptos-move/framework/aptos-token'

--- a/core/sources/domain_e2e_tests.move
+++ b/core/sources/domain_e2e_tests.move
@@ -296,4 +296,19 @@ module aptos_names::domain_e2e_tests {
         // Take the domain name for much longer than users are allowed to register it for
         domains::force_create_or_seize_name(rando, option::none(), test_helper::domain_name(), test_helper::two_hundred_year_secs());
     }
+
+    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    fun clear_name_happy_path_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
+        let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
+        let user = vector::borrow(&users, 0);
+        let user_addr = signer::address_of(user);
+
+        // Register the domain
+        test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
+
+        // Clear my reverse lookup.
+        domains::clear_reverse_lookup(user);
+
+        assert!(option::is_none(&domains::get_reverse_lookup(user_addr)), 1);
+    }
 }

--- a/core/sources/domain_e2e_tests.move
+++ b/core/sources/domain_e2e_tests.move
@@ -127,6 +127,9 @@ module aptos_names::domain_e2e_tests {
         // Lets try to register it again, now that it is expired
         test_helper::register_name(rando, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 2, vector::empty<u8>());
 
+        // Reverse lookup for |user| should be none.
+        assert!(option::is_none(&domains::get_reverse_lookup(signer::address_of(user))), 85);
+
         // And again!
         let (_, expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::none(), test_helper::domain_name());
         timestamp::update_global_time_for_test_secs(expiration_time_sec + 5);

--- a/core/sources/domains.move
+++ b/core/sources/domains.move
@@ -608,6 +608,11 @@ module aptos_names::domains {
         event::counter(&borrow_global<RegisterNameEventsV1>(@aptos_names).register_name_events)
     }
 
+    #[test_only]
+    public fun get_set_reverse_lookup_event_v1_count(): u64 acquires SetReverseLookupEventsV1 {
+        event::counter(&borrow_global<SetReverseLookupEventsV1>(@aptos_names).set_reverse_lookup_events)
+    }
+
     #[test(aptos = @0x1)]
     fun test_time_is_expired(aptos: &signer) {
         timestamp::set_time_has_started_for_testing(aptos);

--- a/core/sources/domains.move
+++ b/core/sources/domains.move
@@ -417,6 +417,9 @@ module aptos_names::domains {
     }
 
     public fun set_name_address(sign: &signer, subdomain_name: Option<String>, domain_name: String, new_address: address) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+        // If the domain name is a primary name, clear it.
+        clear_reverse_lookup_for_name(subdomain_name, domain_name);
+
         let signer_addr = signer::address_of(sign);
         let (is_owner, token_id) = is_owner_of_name(signer_addr, subdomain_name, domain_name);
         assert!(is_owner, error::permission_denied(ENOT_OWNER_OF_NAME));
@@ -527,10 +530,8 @@ module aptos_names::domains {
     public fun set_reverse_lookup(account: &signer, key: &NameRecordKeyV1) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         let account_addr = signer::address_of(account);
         let (maybe_subdomain_name, domain_name) = get_name_record_key_v1_props(key);
-
-        clear_reverse_lookup_for_name(maybe_subdomain_name, domain_name);
-        set_reverse_lookup_internal(account, key);
         set_name_address(account, maybe_subdomain_name, domain_name, account_addr);
+        set_reverse_lookup_internal(account, key);
     }
 
     /// Clears the user's reverse lookup.

--- a/core/sources/domains.move
+++ b/core/sources/domains.move
@@ -293,16 +293,18 @@ module aptos_names::domains {
     /// Forcefully set the name of a domain.
     /// This is a privileged operation, used via governance, to forcefully set a domain address
     /// This can be used, for example, to forcefully set the domain for a system address domain
-    public entry fun force_set_domain_address(sign: &signer, domain_name: String, new_owner: address) acquires NameRegistryV1, SetNameAddressEventsV1 {
+    public entry fun force_set_domain_address(sign: &signer, domain_name: String, new_owner: address) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         force_set_name_address(sign, option::none(), domain_name, new_owner);
     }
 
-    public entry fun force_set_subdomain_address(sign: &signer, subdomain_name: String, domain_name: String, new_owner: address) acquires NameRegistryV1, SetNameAddressEventsV1 {
+    public entry fun force_set_subdomain_address(sign: &signer, subdomain_name: String, domain_name: String, new_owner: address) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         force_set_name_address(sign, option::some(subdomain_name), domain_name, new_owner);
     }
 
-    fun force_set_name_address(sign: &signer, subdomain_name: Option<String>, domain_name: String, new_owner: address) acquires NameRegistryV1, SetNameAddressEventsV1 {
+    fun force_set_name_address(sign: &signer, subdomain_name: Option<String>, domain_name: String, new_owner: address) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         config::assert_signer_is_admin(sign);
+        // If the domain name is a primary name, clear it.
+        clear_reverse_lookup_for_name(subdomain_name, domain_name);
         set_name_address_internal(subdomain_name, domain_name, new_owner);
     }
 

--- a/core/sources/domains.move
+++ b/core/sources/domains.move
@@ -516,6 +516,7 @@ module aptos_names::domains {
         set_name_address(account, maybe_subdomain_name, domain_name, account_addr);
     }
 
+    /// Returns the reverse lookup for an address if any.
     public fun get_reverse_lookup(account_addr: address): Option<NameRecordKeyV1> acquires ReverseLookupRegistryV1 {
         let registry = &borrow_global_mut<ReverseLookupRegistryV1>(@aptos_names).registry;
         if (table::contains(registry, account_addr)) {

--- a/core/sources/test_helper.move
+++ b/core/sources/test_helper.move
@@ -64,9 +64,10 @@ module aptos_names::test_helper {
         let is_subdomain = option::is_some(&subdomain_name);
 
         let user_balance_before = coin::balance<AptosCoin>(user_addr);
+        let user_reverse_lookup_before = domains::get_reverse_lookup(user_addr);
         let register_name_event_v1_event_count_before = domains::get_register_name_event_v1_count();
         let set_name_address_event_v1_event_count_before = domains::get_set_name_address_event_v1_count();
-        let user_reverse_lookup_before = domains::get_reverse_lookup(user_addr);
+        let set_reverse_lookup_event_v1_event_count_before = domains::get_set_reverse_lookup_event_v1_count();
 
         let years = (time_helper::seconds_to_years(registration_duration_secs) as u8);
         if (option::is_none(&subdomain_name)) {
@@ -140,9 +141,17 @@ module aptos_names::test_helper {
         // Assert events have been correctly emmitted
         let register_name_event_v1_num_emitted = domains::get_register_name_event_v1_count() - register_name_event_v1_event_count_before;
         let set_name_address_event_v1_num_emitted = domains::get_set_name_address_event_v1_count() - set_name_address_event_v1_event_count_before;
+        let set_reverse_lookup_event_v1_num_emitted = domains::get_set_reverse_lookup_event_v1_count() - set_reverse_lookup_event_v1_event_count_before;
 
         test_utils::print_actual_expected(b"register_name_event_v1_num_emitted: ", register_name_event_v1_num_emitted, 1, false);
         assert!(register_name_event_v1_num_emitted == 1, register_name_event_v1_num_emitted);
+
+        // Reverse lookup should be set if user did not have one before
+        if (option::is_none(&user_reverse_lookup_before)) {
+            assert!(set_reverse_lookup_event_v1_num_emitted == 1, set_reverse_lookup_event_v1_num_emitted);
+        } else {
+            assert!(set_reverse_lookup_event_v1_num_emitted == 0, set_reverse_lookup_event_v1_num_emitted);
+        };
 
         if (is_subdomain) {
             if (option::is_none(&user_reverse_lookup_before)) {

--- a/core/sources/test_helper.move
+++ b/core/sources/test_helper.move
@@ -148,6 +148,7 @@ module aptos_names::test_helper {
 
         // Reverse lookup should be set if user did not have one before
         if (option::is_none(&user_reverse_lookup_before)) {
+            assert!(option::is_some(&domains::get_reverse_lookup(user_addr)), 36);
             assert!(set_reverse_lookup_event_v1_num_emitted == 1, set_reverse_lookup_event_v1_num_emitted);
         } else {
             assert!(set_reverse_lookup_event_v1_num_emitted == 0, set_reverse_lookup_event_v1_num_emitted);

--- a/core/sources/test_helper.move
+++ b/core/sources/test_helper.move
@@ -148,7 +148,14 @@ module aptos_names::test_helper {
 
         // Reverse lookup should be set if user did not have one before
         if (option::is_none(&user_reverse_lookup_before)) {
-            assert!(option::is_some(&domains::get_reverse_lookup(user_addr)), 36);
+            let maybe_reverse_lookup_after = domains::get_reverse_lookup(user_addr);
+            if (option::is_some(&maybe_reverse_lookup_after)) {
+                let reverse_lookup_after = option::borrow(&maybe_reverse_lookup_after);
+                assert!(*reverse_lookup_after == domains::create_name_record_key_v1(subdomain_name, domain_name), 36);
+            } else {
+                // Reverse lookup is not set, even though user did not have a reverse lookup before.
+                assert!(false, 37);
+            };
             assert!(set_reverse_lookup_event_v1_num_emitted == 1, set_reverse_lookup_event_v1_num_emitted);
         } else {
             assert!(set_reverse_lookup_event_v1_num_emitted == 0, set_reverse_lookup_event_v1_num_emitted);


### PR DESCRIPTION
Adds on-chain reverse lookup (aka primary name)

- Users can set their primary name to a name that they own. This also forces the name to target their own address too.
- If you point your primary name to an address that isn't your own, it is no longer your primary name.
- If you mint a name while you don't have a primary name, your minted name is auto-set to be your primary name. (including minting subdomains)

Notably, if you send your primary name to someone else, it's still your primary name. This will be addressed in a follow-up PR which will allow users to be able to clear the target address of any name that points to them. Clearing the target address of a name forces it to no longer be the primary name of that target address.