### PR TITLE
Updates aptos cli and fixes tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ build
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.aptos

--- a/core/sources/config.move
+++ b/core/sources/config.move
@@ -446,7 +446,7 @@ module aptos_names::config {
 
 
     #[test(myself = @aptos_names, rando = @0x266f, aptos = @0x1)]
-    #[expected_failure(abort_code = 393218)]
+    #[expected_failure(abort_code = 393218, location = aptos_framework::aptos_account)]
     fun test_cant_set_foundation_address_without_coin(myself: &signer, rando: &signer, aptos: &signer) acquires ConfigurationV1 {
         account::create_account_for_test(signer::address_of(myself));
         account::create_account_for_test(signer::address_of(rando));
@@ -462,7 +462,7 @@ module aptos_names::config {
     }
 
     #[test(myself = @aptos_names, rando = @0x266f, aptos = @0x1)]
-    #[expected_failure(abort_code = 327681)]
+    #[expected_failure(abort_code = 327681, location = aptos_names::config)]
     fun test_foundation_config_requires_admin(myself: &signer, rando: &signer, aptos: &signer) acquires ConfigurationV1 {
         account::create_account_for_test(signer::address_of(myself));
         account::create_account_for_test(signer::address_of(rando));
@@ -476,7 +476,7 @@ module aptos_names::config {
     }
 
     #[test(myself = @aptos_names, rando = @0x266f, aptos = @0x1)]
-    #[expected_failure(abort_code = 327681)]
+    #[expected_failure(abort_code = 327681, location = aptos_names::config)]
     fun test_admin_config_requires_admin(myself: &signer, rando: &signer, aptos: &signer) acquires ConfigurationV1 {
         account::create_account_for_test(signer::address_of(myself));
         account::create_account_for_test(signer::address_of(rando));

--- a/core/sources/domain_e2e_tests.move
+++ b/core/sources/domain_e2e_tests.move
@@ -60,7 +60,7 @@ module aptos_names::domain_e2e_tests {
     }
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 65537)]
+    #[expected_failure(abort_code = 65537, location = aptos_names::verify)]
     fun e2e_test_with_invalid_signature(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let signature: vector<u8> = x"2b0340b4529e3f90f0b1af7364241c51172c1133f0c077b7836962c3f104115832ccec0b74382533c33d9bd14a6e68021e5c23439242ddd43047e7929084ac01";
         e2e_test_with_signature(myself, user, aptos, rando, foundation, signature);
@@ -95,7 +95,7 @@ module aptos_names::domain_e2e_tests {
     }
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327696)]
+    #[expected_failure(abort_code = 327696, location = aptos_names::domains)]
     fun test_register_domain_abort_with_disabled_unrestricted_mint(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -144,7 +144,7 @@ module aptos_names::domain_e2e_tests {
     }
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 196611)]
+    #[expected_failure(abort_code = 196611, location = aptos_names::domains)]
     fun dont_allow_double_domain_registrations_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -156,7 +156,7 @@ module aptos_names::domain_e2e_tests {
     }
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327689)]
+    #[expected_failure(abort_code = 327689, location = aptos_names::domains)]
     fun dont_allow_rando_to_set_domain_address_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -169,7 +169,7 @@ module aptos_names::domain_e2e_tests {
     }
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327682)]
+    #[expected_failure(abort_code = 327682, location = aptos_names::domains)]
     fun dont_allow_rando_to_clear_domain_address_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -215,7 +215,7 @@ module aptos_names::domain_e2e_tests {
     }
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327681)]
+    #[expected_failure(abort_code = 327681, location = aptos_names::config)]
     fun rando_cant_force_set_name_address_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -311,7 +311,7 @@ module aptos_names::domain_e2e_tests {
     }
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327681)]
+    #[expected_failure(abort_code = 327681, location = aptos_names::config)]
     fun rando_cant_force_seize_domain_name_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -327,7 +327,7 @@ module aptos_names::domain_e2e_tests {
     }
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327681)]
+    #[expected_failure(abort_code = 327681, location = aptos_names::config)]
     fun rando_cant_force_create_domain_name_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let rando = vector::borrow(&users, 1);

--- a/core/sources/subdomain_e2e_tests.move
+++ b/core/sources/subdomain_e2e_tests.move
@@ -111,7 +111,7 @@ module aptos_names::subdomain_e2e_tests {
     }
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 196611)]
+    #[expected_failure(abort_code = 196611, location = aptos_names::domains)]
     fun dont_allow_double_subdomain_registrations_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -124,7 +124,7 @@ module aptos_names::subdomain_e2e_tests {
     }
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327689)]
+    #[expected_failure(abort_code = 327689, location = aptos_names::domains)]
     fun dont_allow_rando_to_set_subdomain_address_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -138,7 +138,7 @@ module aptos_names::subdomain_e2e_tests {
     }
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327689)]
+    #[expected_failure(abort_code = 327689, location = aptos_names::domains)]
     fun dont_allow_rando_to_clear_subdomain_address_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -171,7 +171,7 @@ module aptos_names::subdomain_e2e_tests {
     }
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327681)]
+    #[expected_failure(abort_code = 327681, location = aptos_names::config)]
     fun rando_cant_force_set_subdomain_address_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -229,7 +229,7 @@ module aptos_names::subdomain_e2e_tests {
     }
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 131086)]
+    #[expected_failure(abort_code = 131086, location = aptos_names::domains)]
     fun admin_cant_force_create_subdomain_more_than_domain_time_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -243,7 +243,7 @@ module aptos_names::subdomain_e2e_tests {
     }
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327681)]
+    #[expected_failure(abort_code = 327681, location = aptos_names::config)]
     fun rando_cant_force_seize_subdomain_name_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -260,7 +260,7 @@ module aptos_names::subdomain_e2e_tests {
     }
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327681)]
+    #[expected_failure(abort_code = 327681, location = aptos_names::config)]
     fun rando_cant_force_create_subdomain_name_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);

--- a/sh_scripts/dev_setup.sh
+++ b/sh_scripts/dev_setup.sh
@@ -11,10 +11,10 @@ if ! command -v aptos &>/dev/null; then
     echo "aptos could not be found"
     echo "installing it..."
     TARGET=Ubuntu-x86_64
-    wget https://github.com/aptos-labs/aptos-core/releases/download/aptos-cli-v1.0.1/aptos-cli-1.0.1-$TARGET.zip
-    sha=$(shasum -a 256 aptos-cli-1.0.1-Ubuntu-x86_64.zip | awk '{ print $1 }')
-    [ "$sha" != "2dceb6da7f4de1c4f9efbb9e171a5721a439e9b2b28554551a51ca8c39230b05" ] && echo "shasum mismatch" && exit 1
-    unzip aptos-cli-1.0.1-Ubuntu-x86_64.zip
+    wget https://github.com/aptos-labs/aptos-core/releases/download/aptos-cli-v1.0.4/aptos-cli-1.0.4-$TARGET.zip
+    sha=$(shasum -a 256 aptos-cli-1.0.4-Ubuntu-x86_64.zip | awk '{ print $1 }')
+    [ "$sha" != "a78beaeef72cc532fc50d3be666a90cb50d09cc61edbfb8711e4173014a4baed" ] && echo "shasum mismatch" && exit 1
+    unzip aptos-cli-1.0.4-Ubuntu-x86_64.zip
     chmod +x aptos
 else
     echo "aptos already installed"


### PR DESCRIPTION
This updates the GH presubmits to use cli version 1.0.4, which also requires all tests to specify the location/source of expected error codes.