### PR TITLE
Improve testing experience with aptos names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ yarn-debug.log*
 yarn-error.log*
 
 .aptos
+.coverage_map.mvcov
+.trace

--- a/core/sources/domains.move
+++ b/core/sources/domains.move
@@ -49,6 +49,8 @@ module aptos_names::domains {
     const EVALID_SIGNATURE_REQUIRED: u64 = 16;
     /// The domain is too short.
     const EDOMAIN_TOO_SHORT: u64 = 17;
+    /// Reverse lookup registry not initialized. `init_reverse_lookup_registry_v1` must be called first
+    const EREVERSE_LOOKUP_NOT_INITIALIZED: u64 = 18;
 
     struct NameRecordKeyV1 has copy, drop, store {
         subdomain_name: Option<String>,
@@ -160,18 +162,27 @@ module aptos_names::domains {
     public entry fun init_reverse_lookup_registry_v1(account: &signer) {
         assert!(signer::address_of(account) == @aptos_names, error::permission_denied(ENOT_AUTHORIZED));
 
-        move_to(account, ReverseLookupRegistryV1 {
-            registry: table::new()
-        });
+        if (!exists<ReverseLookupRegistryV1>(@aptos_names)) {
+            move_to(account, ReverseLookupRegistryV1 {
+                registry: table::new()
+            });
 
-        move_to(account, SetReverseLookupEventsV1 {
-            set_reverse_lookup_events: account::new_event_handle<SetReverseLookupEventV1>(account),
-        });
+            move_to(account, SetReverseLookupEventsV1 {
+                set_reverse_lookup_events: account::new_event_handle<SetReverseLookupEventV1>(account),
+            });
+        };
     }
 
-    fun register_domain_generic(sign: &signer, domain_name: String, num_years: u8) acquires NameRegistryV1, RegisterNameEventsV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    fun register_domain_generic(
+        sign: &signer,
+        domain_name: String,
+        num_years: u8
+    ) acquires NameRegistryV1, RegisterNameEventsV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         assert!(config::is_enabled(), error::unavailable(ENOT_ENABLED));
-        assert!(num_years > 0 && num_years <= config::max_number_of_years_registered(), error::out_of_range(EINVALID_NUMBER_YEARS));
+        assert!(
+            num_years > 0 && num_years <= config::max_number_of_years_registered(),
+            error::out_of_range(EINVALID_NUMBER_YEARS)
+        );
 
         let subdomain_name = option::none<String>();
 
@@ -193,12 +204,21 @@ module aptos_names::domains {
 
     /// A wrapper around `register_name` as an entry function.
     /// Option<String> is not currently serializable, so we have these convenience methods
-    public entry fun register_domain(sign: &signer, domain_name: String, num_years: u8) acquires NameRegistryV1, RegisterNameEventsV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    public entry fun register_domain(
+        sign: &signer,
+        domain_name: String,
+        num_years: u8
+    ) acquires NameRegistryV1, RegisterNameEventsV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         assert!(config::unrestricted_mint_enabled(), error::permission_denied(EVALID_SIGNATURE_REQUIRED));
         register_domain_generic(sign, domain_name, num_years);
     }
 
-    public entry fun register_domain_with_signature(sign: &signer, domain_name: String, num_years: u8, signature: vector<u8>) acquires NameRegistryV1, RegisterNameEventsV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    public entry fun register_domain_with_signature(
+        sign: &signer,
+        domain_name: String,
+        num_years: u8,
+        signature: vector<u8>
+    ) acquires NameRegistryV1, RegisterNameEventsV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         let account_address = signer::address_of(sign);
         verify::assert_register_domain_signature_verifies(signature, account_address, domain_name);
         register_domain_generic(sign, domain_name, num_years);
@@ -207,10 +227,18 @@ module aptos_names::domains {
     /// A wrapper around `register_name` as an entry function.
     /// Option<String> is not currently serializable, so we have these convenience method
     /// `expiration_time_sec` is the timestamp, in seconds, when the name expires
-    public entry fun register_subdomain(sign: &signer, subdomain_name: String, domain_name: String, expiration_time_sec: u64) acquires NameRegistryV1, RegisterNameEventsV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    public entry fun register_subdomain(
+        sign: &signer,
+        subdomain_name: String,
+        domain_name: String,
+        expiration_time_sec: u64
+    ) acquires NameRegistryV1, RegisterNameEventsV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         assert!(config::is_enabled(), error::unavailable(ENOT_ENABLED));
 
-        assert!(name_is_registerable(option::some(subdomain_name), domain_name), error::invalid_state(ENAME_NOT_AVAILABLE));
+        assert!(
+            name_is_registerable(option::some(subdomain_name), domain_name),
+            error::invalid_state(ENAME_NOT_AVAILABLE)
+        );
 
         // We are registering a subdomain name: this has no cost, but is only doable by the owner of the domain
         let (is_valid, length) = utf8_utils::string_is_allowed(&subdomain_name);
@@ -235,7 +263,13 @@ module aptos_names::domains {
     /// For domains, the registration duration is only allowed to be in increments of 1 year, for now
     /// Since the owner of the domain is the only one that can create the subdomain, we allow them to decide how long they want the underlying registration to be
     /// The maximum subdomain registration duration is limited to the duration of its parent domain registration
-    fun register_name_internal(sign: &signer, subdomain_name: Option<String>, domain_name: String, registration_duration_secs: u64, price: u64) acquires NameRegistryV1, RegisterNameEventsV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    fun register_name_internal(
+        sign: &signer,
+        subdomain_name: Option<String>,
+        domain_name: String,
+        registration_duration_secs: u64,
+        price: u64
+    ) acquires NameRegistryV1, RegisterNameEventsV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         // If we're registering a name that exists but is expired, and the expired name is a primary name,
         // it should get removed from being a primary name.
         clear_reverse_lookup_for_name(subdomain_name, domain_name);
@@ -248,8 +282,13 @@ module aptos_names::domains {
         // This is done here so that any governance moderation activities must abide by the same invariant
         if (option::is_some(&subdomain_name)) {
             let domain_name_record_key = create_name_record_key_v1(option::none(), domain_name);
-            let (_property_version, domain_expiration_time_sec, _target_address) = get_name_record_v1_props(table::borrow(&aptos_names.registry, domain_name_record_key));
-            assert!(name_expiration_time_secs <= domain_expiration_time_sec, error::out_of_range(ESUBDOMAIN_CAN_NOT_EXCEED_DOMAIN_REGISTRATION));
+            let (_property_version, domain_expiration_time_sec, _target_address) = get_name_record_v1_props(
+                table::borrow(&aptos_names.registry, domain_name_record_key)
+            );
+            assert!(
+                name_expiration_time_secs <= domain_expiration_time_sec,
+                error::out_of_range(ESUBDOMAIN_CAN_NOT_EXCEED_DOMAIN_REGISTRATION)
+            );
         };
 
         // Create the token, and transfer it to the user
@@ -257,8 +296,17 @@ module aptos_names::domains {
         let token_id = token_helper::create_token(tokendata_id);
 
 
-        let (property_keys, property_values, property_types) = get_name_property_map(subdomain_name, name_expiration_time_secs);
-        token_id = token_helper::set_token_props(token_helper::get_token_signer_address(), property_keys, property_values, property_types, token_id);
+        let (property_keys, property_values, property_types) = get_name_property_map(
+            subdomain_name,
+            name_expiration_time_secs
+        );
+        token_id = token_helper::set_token_props(
+            token_helper::get_token_signer_address(),
+            property_keys,
+            property_values,
+            property_types,
+            token_id
+        );
         token_helper::transfer_token_to(sign, token_id);
 
         // Add this domain to the registry
@@ -293,15 +341,29 @@ module aptos_names::domains {
     /// Forcefully set the name of a domain.
     /// This is a privileged operation, used via governance, to forcefully set a domain address
     /// This can be used, for example, to forcefully set the domain for a system address domain
-    public entry fun force_set_domain_address(sign: &signer, domain_name: String, new_owner: address) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    public entry fun force_set_domain_address(
+        sign: &signer,
+        domain_name: String,
+        new_owner: address
+    ) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         force_set_name_address(sign, option::none(), domain_name, new_owner);
     }
 
-    public entry fun force_set_subdomain_address(sign: &signer, subdomain_name: String, domain_name: String, new_owner: address) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    public entry fun force_set_subdomain_address(
+        sign: &signer,
+        subdomain_name: String,
+        domain_name: String,
+        new_owner: address
+    ) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         force_set_name_address(sign, option::some(subdomain_name), domain_name, new_owner);
     }
 
-    fun force_set_name_address(sign: &signer, subdomain_name: Option<String>, domain_name: String, new_owner: address) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    fun force_set_name_address(
+        sign: &signer,
+        subdomain_name: Option<String>,
+        domain_name: String,
+        new_owner: address
+    ) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         config::assert_signer_is_admin(sign);
         // If the domain name is a primary name, clear it.
         clear_reverse_lookup_for_name(subdomain_name, domain_name);
@@ -313,15 +375,29 @@ module aptos_names::domains {
     /// The `registration_duration_secs` parameter is the number of seconds to register the domain for, but is not limited to the maximum set in the config for domains registered normally.
     /// This allows, for example, to create a domain for the system address for 100 years so we don't need to worry about expiry
     /// Or for moderation purposes, it allows us to seize a racist/harassing domain for 100 years, and park it somewhere safe
-    public entry fun force_create_or_seize_domain_name(sign: &signer, domain_name: String, registration_duration_secs: u64) acquires NameRegistryV1, RegisterNameEventsV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    public entry fun force_create_or_seize_domain_name(
+        sign: &signer,
+        domain_name: String,
+        registration_duration_secs: u64
+    ) acquires NameRegistryV1, RegisterNameEventsV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         force_create_or_seize_name(sign, option::none(), domain_name, registration_duration_secs);
     }
 
-    public entry fun force_create_or_seize_subdomain_name(sign: &signer, subdomain_name: String, domain_name: String, registration_duration_secs: u64) acquires NameRegistryV1, RegisterNameEventsV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    public entry fun force_create_or_seize_subdomain_name(
+        sign: &signer,
+        subdomain_name: String,
+        domain_name: String,
+        registration_duration_secs: u64
+    ) acquires NameRegistryV1, RegisterNameEventsV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         force_create_or_seize_name(sign, option::some(subdomain_name), domain_name, registration_duration_secs);
     }
 
-    public fun force_create_or_seize_name(sign: &signer, subdomain_name: Option<String>, domain_name: String, registration_duration_secs: u64) acquires NameRegistryV1, RegisterNameEventsV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    public fun force_create_or_seize_name(
+        sign: &signer,
+        subdomain_name: Option<String>,
+        domain_name: String,
+        registration_duration_secs: u64
+    ) acquires NameRegistryV1, RegisterNameEventsV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         config::assert_signer_is_admin(sign);
         // Register the name
         register_name_internal(sign, subdomain_name, domain_name, registration_duration_secs, 0);
@@ -330,7 +406,11 @@ module aptos_names::domains {
     #[legacy_entry_fun]
     /// This removes a name mapping from the registry; functionally this 'expires' it.
     /// This is a privileged operation, used via governance.
-    public entry fun force_clear_registration(sign: &signer, subdomain_name: Option<String>, domain_name: String) acquires NameRegistryV1 {
+    public entry fun force_clear_registration(
+        sign: &signer,
+        subdomain_name: Option<String>,
+        domain_name: String
+    ) acquires NameRegistryV1 {
         config::assert_signer_is_admin(sign);
         let name_record_key = create_name_record_key_v1(subdomain_name, domain_name);
         let aptos_names = borrow_global_mut<NameRegistryV1>(@aptos_names);
@@ -374,7 +454,10 @@ module aptos_names::domains {
     }
 
     /// Given a domain and/or a subdomain, returns the name record
-    public fun get_name_record_v1(subdomain_name: Option<String>, domain_name: String): NameRecordV1 acquires NameRegistryV1 {
+    public fun get_name_record_v1(
+        subdomain_name: Option<String>,
+        domain_name: String
+    ): NameRecordV1 acquires NameRegistryV1 {
         assert!(name_is_registered(subdomain_name, domain_name), error::not_found(ENAME_NOT_EXIST));
         let aptos_names = borrow_global<NameRegistryV1>(@aptos_names);
         let name_record_key = create_name_record_key_v1(subdomain_name, domain_name);
@@ -382,7 +465,10 @@ module aptos_names::domains {
     }
 
     /// Given a domain and/or a subdomain, returns the name record properties
-    public fun get_name_record_v1_props_for_name(subdomain_name: Option<String>, domain_name: String): (u64, u64, Option<address>) acquires NameRegistryV1 {
+    public fun get_name_record_v1_props_for_name(
+        subdomain_name: Option<String>,
+        domain_name: String
+    ): (u64, u64, Option<address>) acquires NameRegistryV1 {
         assert!(name_is_registered(subdomain_name, domain_name), error::not_found(ENAME_NOT_EXIST));
         let aptos_names = borrow_global<NameRegistryV1>(@aptos_names);
         let name_record_key = create_name_record_key_v1(subdomain_name, domain_name);
@@ -391,15 +477,26 @@ module aptos_names::domains {
 
     /// Check if the address is the owner of the given aptos_name
     /// If the name does not exist or owner owns an expired name, returns false
-    public fun is_owner_of_name(owner_address: address, subdomain_name: Option<String>, domain_name: String): (bool, TokenId) acquires NameRegistryV1 {
-        let token_data_id = token_helper::build_tokendata_id(token_helper::get_token_signer_address(), subdomain_name, domain_name);
+    public fun is_owner_of_name(
+        owner_address: address,
+        subdomain_name: Option<String>,
+        domain_name: String
+    ): (bool, TokenId) acquires NameRegistryV1 {
+        let token_data_id = token_helper::build_tokendata_id(
+            token_helper::get_token_signer_address(),
+            subdomain_name,
+            domain_name
+        );
         let token_id = token_helper::latest_token_id(&token_data_id);
         (token::balance_of(owner_address, token_id) > 0 && !name_is_expired(subdomain_name, domain_name), token_id)
     }
 
     /// gets the address pointed to by a given name
     /// Is `Option<address>` because the name may not be registered, or it may not have an address associated with it
-    public fun name_resolved_address(subdomain_name: Option<String>, domain_name: String): Option<address> acquires NameRegistryV1 {
+    public fun name_resolved_address(
+        subdomain_name: Option<String>,
+        domain_name: String
+    ): Option<address> acquires NameRegistryV1 {
         let aptos_names = borrow_global<NameRegistryV1>(@aptos_names);
         let name_record_key = create_name_record_key_v1(subdomain_name, domain_name);
         if (table::contains(&aptos_names.registry, name_record_key)) {
@@ -411,15 +508,29 @@ module aptos_names::domains {
         }
     }
 
-    public entry fun set_domain_address(sign: &signer, domain_name: String, new_address: address) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    public entry fun set_domain_address(
+        sign: &signer,
+        domain_name: String,
+        new_address: address
+    ) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         set_name_address(sign, option::none(), domain_name, new_address);
     }
 
-    public entry fun set_subdomain_address(sign: &signer, subdomain_name: String, domain_name: String, new_address: address) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    public entry fun set_subdomain_address(
+        sign: &signer,
+        subdomain_name: String,
+        domain_name: String,
+        new_address: address
+    ) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         set_name_address(sign, option::some(subdomain_name), domain_name, new_address);
     }
 
-    public fun set_name_address(sign: &signer, subdomain_name: Option<String>, domain_name: String, new_address: address) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    public fun set_name_address(
+        sign: &signer,
+        subdomain_name: Option<String>,
+        domain_name: String,
+        new_address: address
+    ) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         // If the domain name is a primary name, clear it.
         clear_reverse_lookup_for_name(subdomain_name, domain_name);
 
@@ -429,7 +540,10 @@ module aptos_names::domains {
 
         let name_record = set_name_address_internal(subdomain_name, domain_name, new_address);
         let (_property_version, expiration_time_sec, _target_address) = get_name_record_v1_props(&name_record);
-        let (property_keys, property_values, property_types) = get_name_property_map(subdomain_name, expiration_time_sec);
+        let (property_keys, property_values, property_types) = get_name_property_map(
+            subdomain_name,
+            expiration_time_sec
+        );
         token_helper::set_token_props(signer_addr, property_keys, property_values, property_types, token_id);
 
         // If the signer's reverse lookup is the domain, and the new address is not the signer, clear the signer's reverse lookup.
@@ -448,7 +562,11 @@ module aptos_names::domains {
         };
     }
 
-    fun set_name_address_internal(subdomain_name: Option<String>, domain_name: String, new_address: address): NameRecordV1 acquires NameRegistryV1, SetNameAddressEventsV1 {
+    fun set_name_address_internal(
+        subdomain_name: Option<String>,
+        domain_name: String,
+        new_address: address
+    ): NameRecordV1 acquires NameRegistryV1, SetNameAddressEventsV1 {
         assert!(name_is_registered(subdomain_name, domain_name), error::not_found(ENAME_NOT_EXIST));
         let name_record_key = create_name_record_key_v1(subdomain_name, domain_name);
         let aptos_names = borrow_global_mut<NameRegistryV1>(@aptos_names);
@@ -465,17 +583,28 @@ module aptos_names::domains {
         *name_record
     }
 
-    public entry fun clear_domain_address(sign: &signer, domain_name: String) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    public entry fun clear_domain_address(
+        sign: &signer,
+        domain_name: String
+    ) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         clear_name_address(sign, option::none(), domain_name);
     }
 
-    public entry fun clear_subdomain_address(sign: &signer, subdomain_name: String, domain_name: String) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    public entry fun clear_subdomain_address(
+        sign: &signer,
+        subdomain_name: String,
+        domain_name: String
+    ) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         clear_name_address(sign, option::some(subdomain_name), domain_name);
     }
 
     /// This is a shared entry point for clearing the address of a domain or subdomain
     /// It enforces owner permissions
-    fun clear_name_address(sign: &signer, subdomain_name: Option<String>, domain_name: String) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    fun clear_name_address(
+        sign: &signer,
+        subdomain_name: Option<String>,
+        domain_name: String
+    ) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         assert!(name_is_registered(subdomain_name, domain_name), error::not_found(ENAME_NOT_EXIST));
 
         let signer_addr = signer::address_of(sign);
@@ -491,7 +620,9 @@ module aptos_names::domains {
 
         // Only the owner or the registered address can clear the address
         let (is_owner, token_id) = is_owner_of_name(signer_addr, subdomain_name, domain_name);
-        let is_name_resolved_address = name_resolved_address(subdomain_name, domain_name) == option::some<address>(signer_addr);
+        let is_name_resolved_address = name_resolved_address(subdomain_name, domain_name) == option::some<address>(
+            signer_addr
+        );
 
         assert!(is_owner || is_name_resolved_address, error::permission_denied(ENOT_AUTHORIZED));
 
@@ -510,13 +641,20 @@ module aptos_names::domains {
 
         if (is_owner) {
             let (_property_version, expiration_time_sec, _target_address) = get_name_record_v1_props(name_record);
-            let (property_keys, property_values, property_types) = get_name_property_map(subdomain_name, expiration_time_sec);
+            let (property_keys, property_values, property_types) = get_name_property_map(
+                subdomain_name,
+                expiration_time_sec
+            );
             token_helper::set_token_props(signer_addr, property_keys, property_values, property_types, token_id);
         };
     }
 
     /// Entry function for |set_reverse_lookup|.
-    public entry fun set_reverse_lookup_entry(account: &signer, subdomain_name: String, domain_name: String) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    public entry fun set_reverse_lookup_entry(
+        account: &signer,
+        subdomain_name: String,
+        domain_name: String
+    ) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         let key = NameRecordKeyV1 {
             subdomain_name: if (string::length(&subdomain_name) > 0) {
                 option::some(subdomain_name)
@@ -530,7 +668,10 @@ module aptos_names::domains {
 
     /// Sets the |account|'s reverse lookup, aka "primary name". This allows a user to specify which of their Aptos Names
     /// is their "primary", so that dapps can display the user's primary name rather than their address.
-    public fun set_reverse_lookup(account: &signer, key: &NameRecordKeyV1) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
+    public fun set_reverse_lookup(
+        account: &signer,
+        key: &NameRecordKeyV1
+    ) acquires NameRegistryV1, ReverseLookupRegistryV1, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         let account_addr = signer::address_of(account);
         let (maybe_subdomain_name, domain_name) = get_name_record_key_v1_props(key);
         set_name_address(account, maybe_subdomain_name, domain_name, account_addr);
@@ -538,7 +679,9 @@ module aptos_names::domains {
     }
 
     /// Entry function for clearing reverse lookup.
-    public entry fun clear_reverse_lookup_entry(account: &signer) acquires ReverseLookupRegistryV1, SetReverseLookupEventsV1 {
+    public entry fun clear_reverse_lookup_entry(
+        account: &signer
+    ) acquires ReverseLookupRegistryV1, SetReverseLookupEventsV1 {
         clear_reverse_lookup(account);
     }
 
@@ -550,6 +693,7 @@ module aptos_names::domains {
 
     /// Returns the reverse lookup for an address if any.
     public fun get_reverse_lookup(account_addr: address): Option<NameRecordKeyV1> acquires ReverseLookupRegistryV1 {
+        assert!(exists<ReverseLookupRegistryV1>(@aptos_names), error::invalid_state(EREVERSE_LOOKUP_NOT_INITIALIZED));
         let registry = &borrow_global_mut<ReverseLookupRegistryV1>(@aptos_names).registry;
         if (table::contains(registry, account_addr)) {
             option::some(*table::borrow(registry, account_addr))
@@ -558,12 +702,16 @@ module aptos_names::domains {
         }
     }
 
-    fun set_reverse_lookup_internal(account: &signer, key: &NameRecordKeyV1) acquires NameRegistryV1, ReverseLookupRegistryV1, SetReverseLookupEventsV1 {
+    fun set_reverse_lookup_internal(
+        account: &signer,
+        key: &NameRecordKeyV1
+    ) acquires NameRegistryV1, ReverseLookupRegistryV1, SetReverseLookupEventsV1 {
         let account_addr = signer::address_of(account);
         let (maybe_subdomain_name, domain_name) = get_name_record_key_v1_props(key);
         let (is_owner, _) = is_owner_of_name(account_addr, maybe_subdomain_name, domain_name);
         assert!(is_owner, error::permission_denied(ENOT_AUTHORIZED));
 
+        assert!(exists<ReverseLookupRegistryV1>(@aptos_names), error::invalid_state(EREVERSE_LOOKUP_NOT_INITIALIZED));
         let registry = &mut borrow_global_mut<ReverseLookupRegistryV1>(@aptos_names).registry;
         table::upsert(registry, account_addr, *key);
 
@@ -574,12 +722,15 @@ module aptos_names::domains {
         );
     }
 
-    fun clear_reverse_lookup_internal(account_addr: address) acquires ReverseLookupRegistryV1, SetReverseLookupEventsV1 {
+    fun clear_reverse_lookup_internal(
+        account_addr: address
+    ) acquires ReverseLookupRegistryV1, SetReverseLookupEventsV1 {
         let maybe_reverse_lookup = get_reverse_lookup(account_addr);
         if (option::is_none(&maybe_reverse_lookup)) {
             return
         };
         let NameRecordKeyV1 { subdomain_name, domain_name } = option::borrow(&maybe_reverse_lookup);
+        assert!(exists<ReverseLookupRegistryV1>(@aptos_names), error::invalid_state(EREVERSE_LOOKUP_NOT_INITIALIZED));
         let registry = &mut borrow_global_mut<ReverseLookupRegistryV1>(@aptos_names).registry;
         table::remove<address, NameRecordKeyV1>(registry, account_addr);
         emit_set_reverse_lookup_event_v1(
@@ -589,19 +740,30 @@ module aptos_names::domains {
         );
     }
 
-    fun clear_reverse_lookup_for_name(subdomain_name: Option<String>, domain_name: String) acquires NameRegistryV1, ReverseLookupRegistryV1, SetReverseLookupEventsV1 {
+    fun clear_reverse_lookup_for_name(
+        subdomain_name: Option<String>,
+        domain_name: String
+    ) acquires NameRegistryV1, ReverseLookupRegistryV1, SetReverseLookupEventsV1 {
         // If the name is a primary name, clear it
         let maybe_target_address = name_resolved_address(subdomain_name, domain_name);
         if (option::is_some(&maybe_target_address)) {
             let target_address = option::borrow(&maybe_target_address);
             let maybe_reverse_lookup = get_reverse_lookup(*target_address);
-            if (option::is_some(&maybe_reverse_lookup) && NameRecordKeyV1 { subdomain_name, domain_name } == *option::borrow(&maybe_reverse_lookup)) {
+            if (option::is_some(
+                &maybe_reverse_lookup
+            ) && NameRecordKeyV1 { subdomain_name, domain_name } == *option::borrow(&maybe_reverse_lookup)) {
                 clear_reverse_lookup_internal(*target_address);
             };
         };
     }
 
-    fun emit_set_name_address_event_v1(subdomain_name: Option<String>, domain_name: String, property_version: u64, expiration_time_secs: u64, new_address: Option<address>) acquires SetNameAddressEventsV1 {
+    fun emit_set_name_address_event_v1(
+        subdomain_name: Option<String>,
+        domain_name: String,
+        property_version: u64,
+        expiration_time_secs: u64,
+        new_address: Option<address>
+    ) acquires SetNameAddressEventsV1 {
         let event = SetNameAddressEventV1 {
             subdomain_name,
             domain_name,
@@ -616,20 +778,28 @@ module aptos_names::domains {
         );
     }
 
-    fun emit_set_reverse_lookup_event_v1(subdomain_name: Option<String>, domain_name: String, target_address: Option<address>) acquires SetReverseLookupEventsV1 {
+    fun emit_set_reverse_lookup_event_v1(
+        subdomain_name: Option<String>,
+        domain_name: String,
+        target_address: Option<address>
+    ) acquires SetReverseLookupEventsV1 {
         let event = SetReverseLookupEventV1 {
             subdomain_name,
             domain_name,
             target_address,
         };
 
+        assert!(exists<ReverseLookupRegistryV1>(@aptos_names), error::invalid_state(EREVERSE_LOOKUP_NOT_INITIALIZED));
         event::emit_event<SetReverseLookupEventV1>(
             &mut borrow_global_mut<SetReverseLookupEventsV1>(@aptos_names).set_reverse_lookup_events,
             event,
         );
     }
 
-    public fun get_name_property_map(subdomain_name: Option<String>, expiration_time_sec: u64): (vector<String>, vector<vector<u8>>, vector<String>) {
+    public fun get_name_property_map(
+        subdomain_name: Option<String>,
+        expiration_time_sec: u64
+    ): (vector<String>, vector<vector<u8>>, vector<String>) {
         let type;
         if (option::is_some(&subdomain_name)) {
             type = property_map::create_property_value(&config::subdomain_type());
@@ -639,12 +809,20 @@ module aptos_names::domains {
         let expiration_time_sec = property_map::create_property_value(&expiration_time_sec);
 
         let property_keys: vector<String> = vector[config::config_key_type(), config::config_key_expiration_time_sec()];
-        let property_values: vector<vector<u8>> = vector[ property_map::borrow_value(&type), property_map::borrow_value(&expiration_time_sec)];
-        let property_types: vector<String> = vector[property_map::borrow_type(&type), property_map::borrow_type(&expiration_time_sec)];
+        let property_values: vector<vector<u8>> = vector[ property_map::borrow_value(&type), property_map::borrow_value(
+            &expiration_time_sec
+        )];
+        let property_types: vector<String> = vector[property_map::borrow_type(&type), property_map::borrow_type(
+            &expiration_time_sec
+        )];
         (property_keys, property_values, property_types)
     }
 
-    public fun create_name_record_v1(property_version: u64, expiration_time_sec: u64, target_address: Option<address>): NameRecordV1 {
+    public fun create_name_record_v1(
+        property_version: u64,
+        expiration_time_sec: u64,
+        target_address: Option<address>
+    ): NameRecordV1 {
         NameRecordV1 {
             property_version,
             expiration_time_sec,
@@ -690,6 +868,7 @@ module aptos_names::domains {
 
     #[test_only]
     public fun get_set_reverse_lookup_event_v1_count(): u64 acquires SetReverseLookupEventsV1 {
+        assert!(exists<ReverseLookupRegistryV1>(@aptos_names), error::invalid_state(EREVERSE_LOOKUP_NOT_INITIALIZED));
         event::counter(&borrow_global<SetReverseLookupEventsV1>(@aptos_names).set_reverse_lookup_events)
     }
 


### PR DESCRIPTION
Ensure that there's a check that the reverse lookup registry actually exists when deploying to a non-mainnet scenario

```
aptos move test --package-dir core --named-addresses aptos_names=0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c,aptos_names_ad
min=0x91945b4672607a327019e768dd6045d1254d1102d882df434ca734250bb3581d,aptos_names_funds=0x78ee3915e67ef5d19fa91d1e05e60ae08751efd12ce58e23fc1109de87ea7865 --coverage

INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY AptosToken
INCLUDING DEPENDENCY MoveStdlib
BUILDING aptos_names
Running Move unit tests
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::time_helper::test_time_conversion
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::token_helper::test_combine_sub_and_domain_str
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::utf8_utils::test_latin_digits
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domains::test_time_is_expired
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::utf8_utils::test_utf8_to_vec_u64_fast
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::token_helper::test_combine_sub_and_domain_str_dom_only
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::token_helper::test_get_fully_qualified_domain_name
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::config::test_admin_config_requires_admin
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::price_model::test_price_for_domain_v1
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::config::test_cant_set_foundation_address_without_coin
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::price_model::test_scale_price_for_years
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::admin_can_force_create_domain_name_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::config::test_configs_are_set
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::subdomain_e2e_tests::admin_can_force_create_subdomain_name_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::config::test_default_token_configs_are_set
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::admin_can_force_seize_domain_name_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::config::test_default_tokens_configs_are_set
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::config::test_foundation_config_requires_admin
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::admin_can_force_set_name_address_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::subdomain_e2e_tests::admin_can_force_seize_subdomain_name_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::subdomain_e2e_tests::admin_can_force_set_subdomain_address_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::admin_force_seize_domain_name_doesnt_clear_unrelated_primary_name_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::subdomain_e2e_tests::admin_cant_force_create_subdomain_more_than_domain_time_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::clear_name_happy_path_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::dont_allow_double_domain_registrations_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::subdomain_e2e_tests::dont_allow_double_subdomain_registrations_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::dont_allow_rando_to_clear_domain_address_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::subdomain_e2e_tests::dont_allow_rando_to_clear_subdomain_address_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::dont_allow_rando_to_set_domain_address_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::e2e_test_with_invalid_signature
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::subdomain_e2e_tests::dont_allow_rando_to_set_subdomain_address_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::e2e_test_with_valid_signature
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::subdomain_e2e_tests::happy_path_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::happy_path_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::names_are_registerable_after_expiry_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::subdomain_e2e_tests::names_are_registerable_after_expiry_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::owner_can_clear_domain_address_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::subdomain_e2e_tests::rando_cant_force_create_subdomain_name_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::owner_of_expired_name_is_not_owner
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::rando_cant_force_create_domain_name_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::subdomain_e2e_tests::rando_cant_force_seize_subdomain_name_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::rando_cant_force_seize_domain_name_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::subdomain_e2e_tests::rando_cant_force_set_subdomain_address_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::rando_cant_force_set_name_address_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::set_primary_name_after_transfer_clears_old_primary_name_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::set_target_address_after_transfer_clears_old_primary_name_e2e_test
[ PASS    ] 0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domain_e2e_tests::test_register_domain_abort_with_disabled_unrestricted_mint
Test result: OK. Total tests: 47; passed: 47; failed: 0
+-------------------------+
| Move Coverage Summary   |
+-------------------------+
Module 867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::utf8_utils
>>> % Module coverage: 95.86
Module 867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::config
>>> % Module coverage: 94.68
Module 867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::verify
>>> % Module coverage: 100.00
Module 867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::token_helper
>>> % Module coverage: 94.66
Module 867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::time_helper
>>> % Module coverage: 100.00
Module 867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::price_model
>>> % Module coverage: 94.44
Module 867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c::domains
>>> % Module coverage: 85.16
+-------------------------+
| % Move Coverage: 90.12  |
+-------------------------+
Please use `aptos move coverage -h` for more detailed source or bytecode test coverage of this package
{
  "Result": "Success"
}
```