### PR TITLE
Migrate ReverseLookupRegistry from Table to object

### DIFF
--- a/core_v2/sources/domains.move
+++ b/core_v2/sources/domains.move
@@ -595,9 +595,9 @@ module aptos_names_v2::domains {
         if (option::is_none(&maybe_reverse_lookup)) {
             return
         };
-        let reverse_record = borrow_global<NameRecordV2>(*option::borrow(&maybe_reverse_lookup));
-        if (reverse_record.domain_name == domain_name &&
-            reverse_record.subdomain_name == subdomain_name &&
+        let reverse_name_record = borrow_global<NameRecordV2>(*option::borrow(&maybe_reverse_lookup));
+        if (reverse_name_record.domain_name == domain_name &&
+            reverse_name_record.subdomain_name == subdomain_name &&
             signer_addr != new_address
         ) {
             clear_reverse_lookup(sign);


### PR DESCRIPTION
### Description

Use `object` keyed by the user's address (object seed) in to store and access a `ReverseRecord` struct.

### Test Plan

Pass GH action unit tests