### PR TITLE
Rename package from aptos_names to aptos_names_v2

### DIFF
--- a/core_v2/Move.toml
+++ b/core_v2/Move.toml
@@ -1,9 +1,9 @@
 [package]
-name = 'aptos_names'
+name = 'aptos_names_v2'
 version = '1.0.0'
 
 [addresses]
-aptos_names = "_"
+aptos_names_v2 = "_"
 aptos_names_admin = "_"
 aptos_names_funds = "_"
 

--- a/core_v2/sources/config.move
+++ b/core_v2/sources/config.move
@@ -5,14 +5,14 @@ This includes things like the maximum number of years that a name can be registe
 Anyone can read, but only admins can write, as all write methods are gated via permissions checks
 */
 
-module aptos_names::config {
-    friend aptos_names::domains;
-    friend aptos_names::verify;
+module aptos_names_v2::config {
+    friend aptos_names_v2::domains;
+    friend aptos_names_v2::verify;
 
     use aptos_framework::account;
     use aptos_framework::aptos_account;
     use aptos_std::ed25519::{Self, UnvalidatedPublicKey};
-    use aptos_names::utf8_utils;
+    use aptos_names_v2::utf8_utils;
     use aptos_token::property_map::{Self, PropertyMap};
     use std::error;
     use std::signer;
@@ -55,7 +55,7 @@ module aptos_names::config {
         });
 
         // Temporarily set this to framework to allow other methods below to be set with framework signer
-        set_v1(@aptos_names, config_key_admin_address(), &signer::address_of(framework));
+        set_v1(@aptos_names_v2, config_key_admin_address(), &signer::address_of(framework));
 
         set_is_enabled(framework, true);
 
@@ -80,8 +80,8 @@ module aptos_names::config {
         set_unrestricted_mint_enabled(framework, true);
 
         // We set it directly here to allow boostrapping the other values
-        set_v1(@aptos_names, config_key_fund_destination_address(), &fund_destination_address);
-        set_v1(@aptos_names, config_key_admin_address(), &admin_address);
+        set_v1(@aptos_names_v2, config_key_fund_destination_address(), &fund_destination_address);
+        set_v1(@aptos_names_v2, config_key_admin_address(), &admin_address);
     }
 
 
@@ -94,34 +94,34 @@ module aptos_names::config {
     }
 
     public fun is_enabled(): bool acquires ConfigurationV1 {
-        read_bool_v1(@aptos_names, &config_key_enabled())
+        read_bool_v1(@aptos_names_v2, &config_key_enabled())
     }
 
     public fun fund_destination_address(): address acquires ConfigurationV1 {
-        read_address_v1(@aptos_names, &config_key_fund_destination_address())
+        read_address_v1(@aptos_names_v2, &config_key_fund_destination_address())
     }
 
     public fun admin_address(): address acquires ConfigurationV1 {
-        read_address_v1(@aptos_names, &config_key_admin_address())
+        read_address_v1(@aptos_names_v2, &config_key_admin_address())
     }
 
     public fun max_number_of_years_registered(): u8 acquires ConfigurationV1 {
-        read_u8_v1(@aptos_names, &config_key_max_number_of_years_registered())
+        read_u8_v1(@aptos_names_v2, &config_key_max_number_of_years_registered())
     }
 
     public fun max_domain_length(): u64 acquires ConfigurationV1 {
-        read_u64_v1(@aptos_names, &config_key_max_domain_length())
+        read_u64_v1(@aptos_names_v2, &config_key_max_domain_length())
     }
 
     public fun min_domain_length(): u64 acquires ConfigurationV1 {
-        read_u64_v1(@aptos_names, &config_key_min_domain_length())
+        read_u64_v1(@aptos_names_v2, &config_key_min_domain_length())
     }
 
     /// Admins will be able to intervene when necessary.
     /// The account will be used to manage names that are being used in a way that is harmful to others.
     /// Alternatively, the deployer can be used to perform admin actions.
     public fun signer_is_admin(sign: &signer): bool acquires ConfigurationV1 {
-        signer::address_of(sign) == admin_address() || signer::address_of(sign) == @aptos_names
+        signer::address_of(sign) == admin_address() || signer::address_of(sign) == @aptos_names_v2
     }
 
     public fun assert_signer_is_admin(sign: &signer) acquires ConfigurationV1 {
@@ -129,11 +129,11 @@ module aptos_names::config {
     }
 
     public fun tokendata_description(): String acquires ConfigurationV1 {
-        read_string_v1(@aptos_names, &config_key_tokendata_description())
+        read_string_v1(@aptos_names_v2, &config_key_tokendata_description())
     }
 
     public fun tokendata_url_prefix(): String acquires ConfigurationV1 {
-        read_string_v1(@aptos_names, &config_key_tokendata_url_prefix())
+        read_string_v1(@aptos_names_v2, &config_key_tokendata_url_prefix())
     }
 
     public fun domain_type(): String {
@@ -149,19 +149,19 @@ module aptos_names::config {
     }
 
     public fun domain_price_for_length(domain_length: u64): u64 acquires ConfigurationV1 {
-        read_u64_v1(@aptos_names, &config_key_domain_price(domain_length))
+        read_u64_v1(@aptos_names_v2, &config_key_domain_price(domain_length))
     }
 
     public fun subdomain_price(): u64 acquires ConfigurationV1 {
-        read_u64_v1(@aptos_names, &config_key_subdomain_price())
+        read_u64_v1(@aptos_names_v2, &config_key_subdomain_price())
     }
 
     public fun captcha_public_key(): UnvalidatedPublicKey acquires ConfigurationV1 {
-        read_unvalidated_public_key(@aptos_names, &config_key_captcha_public_key())
+        read_unvalidated_public_key(@aptos_names_v2, &config_key_captcha_public_key())
     }
 
     public fun unrestricted_mint_enabled(): bool acquires ConfigurationV1 {
-        read_bool_v1(@aptos_names, &config_key_unrestricted_mint_enabled())
+        read_bool_v1(@aptos_names_v2, &config_key_unrestricted_mint_enabled())
     }
 
     //
@@ -170,72 +170,72 @@ module aptos_names::config {
 
     public entry fun set_is_enabled(sign: &signer, enabled: bool) acquires ConfigurationV1 {
         assert_signer_is_admin(sign);
-        set_v1(@aptos_names, config_key_enabled(), &enabled)
+        set_v1(@aptos_names_v2, config_key_enabled(), &enabled)
     }
 
     public entry fun set_fund_destination_address(sign: &signer, addr: address) acquires ConfigurationV1 {
         assert_signer_is_admin(sign);
         aptos_account::assert_account_is_registered_for_apt(addr);
 
-        set_v1(@aptos_names, config_key_fund_destination_address(), &addr)
+        set_v1(@aptos_names_v2, config_key_fund_destination_address(), &addr)
     }
 
     public entry fun set_admin_address(sign: &signer, addr: address) acquires ConfigurationV1 {
         assert_signer_is_admin(sign);
         assert!(account::exists_at(addr), error::invalid_argument(EINVALID_VALUE));
-        set_v1(@aptos_names, config_key_admin_address(), &addr)
+        set_v1(@aptos_names_v2, config_key_admin_address(), &addr)
     }
 
     public entry fun set_max_number_of_years_registered(sign: &signer, max_years_registered: u8) acquires ConfigurationV1 {
         assert_signer_is_admin(sign);
         assert!(max_years_registered > 0, error::invalid_argument(EINVALID_VALUE));
-        set_v1(@aptos_names, config_key_max_number_of_years_registered(), &max_years_registered)
+        set_v1(@aptos_names_v2, config_key_max_number_of_years_registered(), &max_years_registered)
     }
 
     public entry fun set_max_domain_length(sign: &signer, domain_length: u64) acquires ConfigurationV1 {
         assert_signer_is_admin(sign);
         assert!(domain_length > 0, error::invalid_argument(EINVALID_VALUE));
-        set_v1(@aptos_names, config_key_max_domain_length(), &domain_length)
+        set_v1(@aptos_names_v2, config_key_max_domain_length(), &domain_length)
     }
 
     public entry fun set_min_domain_length(sign: &signer, domain_length: u64) acquires ConfigurationV1 {
         assert_signer_is_admin(sign);
         assert!(domain_length > 0, error::invalid_argument(EINVALID_VALUE));
-        set_v1(@aptos_names, config_key_min_domain_length(), &domain_length)
+        set_v1(@aptos_names_v2, config_key_min_domain_length(), &domain_length)
     }
 
     public entry fun set_tokendata_description(sign: &signer, description: String) acquires ConfigurationV1 {
         assert_signer_is_admin(sign);
-        set_v1(@aptos_names, config_key_tokendata_description(), &description)
+        set_v1(@aptos_names_v2, config_key_tokendata_description(), &description)
     }
 
     public entry fun set_tokendata_url_prefix(sign: &signer, description: String) acquires ConfigurationV1 {
         assert_signer_is_admin(sign);
-        set_v1(@aptos_names, config_key_tokendata_url_prefix(), &description)
+        set_v1(@aptos_names_v2, config_key_tokendata_url_prefix(), &description)
     }
 
     public entry fun set_subdomain_price(sign: &signer, price: u64) acquires ConfigurationV1 {
         assert_signer_is_admin(sign);
-        set_v1(@aptos_names, config_key_subdomain_price(), &price)
+        set_v1(@aptos_names_v2, config_key_subdomain_price(), &price)
     }
 
     public entry fun set_domain_price_for_length(sign: &signer, price: u64, length: u64) acquires ConfigurationV1 {
         assert_signer_is_admin(sign);
         assert!(price > 0, error::invalid_argument(EINVALID_VALUE));
         assert!(length > 0, error::invalid_argument(EINVALID_VALUE));
-        set_v1(@aptos_names, config_key_domain_price(length), &price)
+        set_v1(@aptos_names_v2, config_key_domain_price(length), &price)
     }
 
     public entry fun set_captcha_public_key(sign: &signer, public_key: vector<u8>) acquires ConfigurationV1 {
         assert_signer_is_admin(sign);
-        set_v1(@aptos_names, config_key_captcha_public_key(), &ed25519::new_unvalidated_public_key_from_bytes(public_key));
+        set_v1(@aptos_names_v2, config_key_captcha_public_key(), &ed25519::new_unvalidated_public_key_from_bytes(public_key));
     }
 
     // set if we want to allow users to bypass signature verification
     // when unrestricted_mint_enabled == false, signature verification is required for registering a domain
     public entry fun set_unrestricted_mint_enabled(sign: &signer, unrestricted_mint_enabled: bool) acquires ConfigurationV1 {
         assert_signer_is_admin(sign);
-        set_v1(@aptos_names, config_key_unrestricted_mint_enabled(), &unrestricted_mint_enabled);
+        set_v1(@aptos_names_v2, config_key_unrestricted_mint_enabled(), &unrestricted_mint_enabled);
     }
 
     //
@@ -350,7 +350,7 @@ module aptos_names::config {
     //
 
     #[test_only]
-    friend aptos_names::price_model;
+    friend aptos_names_v2::price_model;
     #[test_only]
     use aptos_framework::coin;
     #[test_only]
@@ -368,28 +368,28 @@ module aptos_names::config {
 
     #[test_only]
     public fun set_fund_destination_address_test_only(addr: address) acquires ConfigurationV1 {
-        set_v1(@aptos_names, config_key_fund_destination_address(), &addr)
+        set_v1(@aptos_names_v2, config_key_fund_destination_address(), &addr)
     }
 
     #[test_only]
     public fun set_admin_address_test_only(addr: address) acquires ConfigurationV1 {
-        set_v1(@aptos_names, config_key_admin_address(), &addr)
+        set_v1(@aptos_names_v2, config_key_admin_address(), &addr)
     }
 
     #[test_only]
-    public fun initialize_for_test(aptos_names: &signer, aptos: &signer) acquires ConfigurationV1 {
+    public fun initialize_for_test(aptos_names_v2: &signer, aptos: &signer) acquires ConfigurationV1 {
         timestamp::set_time_has_started_for_testing(aptos);
         initialize_aptoscoin_for(aptos);
-        initialize_v1(aptos_names, @aptos_names, @aptos_names);
-        set_admin_address_test_only(signer::address_of(aptos_names));
+        initialize_v1(aptos_names_v2, @aptos_names_v2, @aptos_names_v2);
+        set_admin_address_test_only(signer::address_of(aptos_names_v2));
     }
 
-    #[test(myself = @aptos_names)]
+    #[test(myself = @aptos_names_v2)]
     fun test_default_token_configs_are_set(myself: signer) acquires ConfigurationV1 {
         account::create_account_for_test(signer::address_of(&myself));
 
-        initialize_v1(&myself, @aptos_names, @aptos_names);
-        set_v1(@aptos_names, config_key_admin_address(), &@aptos_names);
+        initialize_v1(&myself, @aptos_names_v2, @aptos_names_v2);
+        set_v1(@aptos_names_v2, config_key_admin_address(), &@aptos_names_v2);
 
         set_tokendata_description(&myself, string::utf8(b"test description"));
         assert!(tokendata_description() == string::utf8(b"test description"), 1);
@@ -398,12 +398,12 @@ module aptos_names::config {
         assert!(tokendata_url_prefix() == string::utf8(b"test_prefix"), 1);
     }
 
-    #[test(myself = @aptos_names)]
+    #[test(myself = @aptos_names_v2)]
     fun test_default_tokens_configs_are_set(myself: signer) acquires ConfigurationV1 {
         account::create_account_for_test(signer::address_of(&myself));
 
-        initialize_v1(&myself, @aptos_names, @aptos_names);
-        set_v1(@aptos_names, config_key_admin_address(), &@aptos_names);
+        initialize_v1(&myself, @aptos_names_v2, @aptos_names_v2);
+        set_v1(@aptos_names_v2, config_key_admin_address(), &@aptos_names_v2);
 
         set_tokendata_description(&myself, string::utf8(b"test description"));
         assert!(tokendata_description() == string::utf8(b"test description"), 1);
@@ -412,7 +412,7 @@ module aptos_names::config {
         set_tokendata_description(&myself, string::utf8(b"test_desc"));
     }
 
-    #[test(myself = @aptos_names, rando = @0x266f, aptos = @0x1)]
+    #[test(myself = @aptos_names_v2, rando = @0x266f, aptos = @0x1)]
     fun test_configs_are_set(myself: &signer, rando: &signer, aptos: &signer) acquires ConfigurationV1 {
         account::create_account_for_test(signer::address_of(myself));
         account::create_account_for_test(signer::address_of(rando));
@@ -445,7 +445,7 @@ module aptos_names::config {
     }
 
 
-    #[test(myself = @aptos_names, rando = @0x266f, aptos = @0x1)]
+    #[test(myself = @aptos_names_v2, rando = @0x266f, aptos = @0x1)]
     #[expected_failure(abort_code = 393218, location = aptos_framework::aptos_account)]
     fun test_cant_set_foundation_address_without_coin(myself: &signer, rando: &signer, aptos: &signer) acquires ConfigurationV1 {
         account::create_account_for_test(signer::address_of(myself));
@@ -461,8 +461,8 @@ module aptos_names::config {
         assert!(fund_destination_address() == signer::address_of(rando), 5);
     }
 
-    #[test(myself = @aptos_names, rando = @0x266f, aptos = @0x1)]
-    #[expected_failure(abort_code = 327681, location = aptos_names::config)]
+    #[test(myself = @aptos_names_v2, rando = @0x266f, aptos = @0x1)]
+    #[expected_failure(abort_code = 327681, location = aptos_names_v2::config)]
     fun test_foundation_config_requires_admin(myself: &signer, rando: &signer, aptos: &signer) acquires ConfigurationV1 {
         account::create_account_for_test(signer::address_of(myself));
         account::create_account_for_test(signer::address_of(rando));
@@ -475,8 +475,8 @@ module aptos_names::config {
         set_fund_destination_address(rando, signer::address_of(rando));
     }
 
-    #[test(myself = @aptos_names, rando = @0x266f, aptos = @0x1)]
-    #[expected_failure(abort_code = 327681, location = aptos_names::config)]
+    #[test(myself = @aptos_names_v2, rando = @0x266f, aptos = @0x1)]
+    #[expected_failure(abort_code = 327681, location = aptos_names_v2::config)]
     fun test_admin_config_requires_admin(myself: &signer, rando: &signer, aptos: &signer) acquires ConfigurationV1 {
         account::create_account_for_test(signer::address_of(myself));
         account::create_account_for_test(signer::address_of(rando));

--- a/core_v2/sources/domain_e2e_tests.move
+++ b/core_v2/sources/domain_e2e_tests.move
@@ -1,19 +1,19 @@
 #[test_only]
-module aptos_names::domain_e2e_tests {
+module aptos_names_v2::domain_e2e_tests {
     use aptos_framework::chain_id;
     use aptos_framework::timestamp;
     use aptos_framework::object;
-    use aptos_names::config;
-    use aptos_names::domains;
-    use aptos_names::time_helper;
-    use aptos_names::test_helper;
-    use aptos_names::test_utils;
+    use aptos_names_v2::config;
+    use aptos_names_v2::domains;
+    use aptos_names_v2::time_helper;
+    use aptos_names_v2::test_helper;
+    use aptos_names_v2::test_utils;
     use std::option;
     use std::signer;
     use std::string;
     use std::vector;
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun happy_path_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -38,14 +38,14 @@ module aptos_names::domain_e2e_tests {
         test_helper::set_name_address(user, option::none(), test_helper::domain_name(), user_addr);
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun e2e_test_with_valid_signature(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         /*
           Signature generated with scripts/generateKeys.ts
             yarn ts-node --compilerOptions '{"target": "es6", "module": "commonjs", "esModuleInterop": true}'  ./scripts/generateKeys.ts
 
           let proof_struct = RegisterDomainProofChallenge {
-              account_address: AccountAddress::from_hex_literal(APTOS_NAMES).unwrap(),
+              account_address: AccountAddress::from_hex_literal(aptos_names_v2).unwrap(),
               module_name: String::from("verify"),
               struct_name: String::from("RegisterDomainProofChallenge"),
               sequence_number: 0,
@@ -59,8 +59,8 @@ module aptos_names::domain_e2e_tests {
         e2e_test_with_signature(myself, user, aptos, rando, foundation, signature);
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 65537, location = aptos_names::verify)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[expected_failure(abort_code = 65537, location = aptos_names_v2::verify)]
     fun e2e_test_with_invalid_signature(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let signature: vector<u8> = x"2b0340b4529e3f90f0b1af7364241c51172c1133f0c077b7836962c3f104115832ccec0b74382533c33d9bd14a6e68021e5c23439242ddd43047e7929084ac01";
         e2e_test_with_signature(myself, user, aptos, rando, foundation, signature);
@@ -94,8 +94,8 @@ module aptos_names::domain_e2e_tests {
         test_helper::set_name_address(user, option::none(), test_helper::domain_name(), user_addr);
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327696, location = aptos_names::domains)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[expected_failure(abort_code = 327696, location = aptos_names_v2::domains)]
     fun test_register_domain_abort_with_disabled_unrestricted_mint(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -106,7 +106,7 @@ module aptos_names::domain_e2e_tests {
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun names_are_registerable_after_expiry_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -143,8 +143,8 @@ module aptos_names::domain_e2e_tests {
         test_helper::register_name(rando, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 3, vector::empty<u8>());
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 196611, location = aptos_names::domains)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[expected_failure(abort_code = 196611, location = aptos_names_v2::domains)]
     fun dont_allow_double_domain_registrations_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -155,8 +155,8 @@ module aptos_names::domain_e2e_tests {
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327689, location = aptos_names::domains)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[expected_failure(abort_code = 327689, location = aptos_names_v2::domains)]
     fun dont_allow_rando_to_set_domain_address_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -165,11 +165,11 @@ module aptos_names::domain_e2e_tests {
         // Register the domain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
         // Ensure we can't set it as a rando. The expected target address doesn't matter as it won't get hit
-        test_helper::set_name_address(rando, option::none(), test_helper::domain_name(), @aptos_names);
+        test_helper::set_name_address(rando, option::none(), test_helper::domain_name(), @aptos_names_v2);
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327682, location = aptos_names::domains)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[expected_failure(abort_code = 327682, location = aptos_names_v2::domains)]
     fun dont_allow_rando_to_clear_domain_address_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -183,7 +183,7 @@ module aptos_names::domain_e2e_tests {
         test_helper::clear_name_address(rando, option::none(), test_helper::domain_name());
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun owner_can_clear_domain_address_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -197,7 +197,7 @@ module aptos_names::domain_e2e_tests {
         test_helper::clear_name_address(user, option::none(), test_helper::domain_name());
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun admin_can_force_set_name_address_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -214,8 +214,8 @@ module aptos_names::domain_e2e_tests {
         assert!(target_address == option::some(rando_addr), 33);
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327681, location = aptos_names::config)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[expected_failure(abort_code = 327681, location = aptos_names_v2::config)]
     fun rando_cant_force_set_name_address_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -231,7 +231,7 @@ module aptos_names::domain_e2e_tests {
     }
 
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun admin_can_force_seize_domain_name_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -255,7 +255,7 @@ module aptos_names::domain_e2e_tests {
         assert!(option::is_none(&domains::get_reverse_lookup(user_addr)), 1);
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun admin_force_seize_domain_name_doesnt_clear_unrelated_primary_name_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -288,7 +288,7 @@ module aptos_names::domain_e2e_tests {
         assert!(option::is_some(&domains::get_reverse_lookup(user_addr)), 1);
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun admin_can_force_create_domain_name_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let _ = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
 
@@ -310,8 +310,8 @@ module aptos_names::domain_e2e_tests {
         assert!(!domains::name_is_registered(option::none(), test_helper::domain_name()), 4);
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327681, location = aptos_names::config)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[expected_failure(abort_code = 327681, location = aptos_names_v2::config)]
     fun rando_cant_force_seize_domain_name_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -326,8 +326,8 @@ module aptos_names::domain_e2e_tests {
         domains::force_create_or_seize_name(rando, option::none(), test_helper::domain_name(), test_helper::two_hundred_year_secs());
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327681, location = aptos_names::config)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[expected_failure(abort_code = 327681, location = aptos_names_v2::config)]
     fun rando_cant_force_create_domain_name_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let rando = vector::borrow(&users, 1);
@@ -339,7 +339,7 @@ module aptos_names::domain_e2e_tests {
         domains::force_create_or_seize_name(rando, option::none(), test_helper::domain_name(), test_helper::two_hundred_year_secs());
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun clear_name_happy_path_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -354,7 +354,7 @@ module aptos_names::domain_e2e_tests {
         assert!(option::is_none(&domains::get_reverse_lookup(user_addr)), 1);
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun set_primary_name_after_transfer_clears_old_primary_name_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -384,7 +384,7 @@ module aptos_names::domain_e2e_tests {
         assert!(*option::borrow(&domains::name_resolved_address(option::none(), test_helper::domain_name())) == rando_addr, 1);
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun set_target_address_after_transfer_clears_old_primary_name_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -414,7 +414,7 @@ module aptos_names::domain_e2e_tests {
         assert!(*option::borrow(&domains::name_resolved_address(option::none(), test_helper::domain_name())) == rando_addr, 1);
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun owner_of_expired_name_is_not_owner(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);

--- a/core_v2/sources/domains.move
+++ b/core_v2/sources/domains.move
@@ -1,4 +1,4 @@
-module aptos_names::domains {
+module aptos_names_v2::domains {
     use aptos_framework::account::{Self, SignerCapability};
     use aptos_framework::aptos_account;
     use aptos_framework::aptos_coin::AptosCoin;
@@ -6,12 +6,12 @@ module aptos_names::domains {
     use aptos_framework::event;
     use aptos_framework::object::{Self, Object};
     use aptos_framework::timestamp;
-    use aptos_names::config;
-    use aptos_names::price_model;
-    use aptos_names::time_helper;
-    use aptos_names::token_helper;
-    use aptos_names::utf8_utils;
-    use aptos_names::verify;
+    use aptos_names_v2::config;
+    use aptos_names_v2::price_model;
+    use aptos_names_v2::time_helper;
+    use aptos_names_v2::token_helper;
+    use aptos_names_v2::utf8_utils;
+    use aptos_names_v2::verify;
     use aptos_std::table::{Self, Table};
     use aptos_token_objects::collection;
     use aptos_token_objects::token;
@@ -173,11 +173,11 @@ module aptos_names::domains {
     }
     
     public fun get_token_signer_address(): address acquires CollectionCapabilityV2 {
-        account::get_signer_capability_address(&borrow_global<CollectionCapabilityV2>(@aptos_names).capability)
+        account::get_signer_capability_address(&borrow_global<CollectionCapabilityV2>(@aptos_names_v2).capability)
     }
 
     fun get_token_signer(): signer acquires CollectionCapabilityV2 {
-        account::create_signer_with_capability(&borrow_global<CollectionCapabilityV2>(@aptos_names).capability)
+        account::create_signer_with_capability(&borrow_global<CollectionCapabilityV2>(@aptos_names_v2).capability)
     }
 
     inline fun token_addr_inline(
@@ -401,7 +401,7 @@ module aptos_names::domains {
         };
 
         event::emit_event<RegisterNameEventV1>(
-            &mut borrow_global_mut<RegisterNameEventsV1>(@aptos_names).register_name_events,
+            &mut borrow_global_mut<RegisterNameEventsV1>(@aptos_names_v2).register_name_events,
             RegisterNameEventV1 {
                 subdomain_name,
                 domain_name,
@@ -714,8 +714,8 @@ module aptos_names::domains {
     public fun get_reverse_lookup(
         account_addr: address
     ): Option<address> acquires ReverseLookupRegistryV1 {
-        assert!(exists<ReverseLookupRegistryV1>(@aptos_names), error::invalid_state(EREVERSE_LOOKUP_NOT_INITIALIZED));
-        let registry = &borrow_global_mut<ReverseLookupRegistryV1>(@aptos_names).registry;
+        assert!(exists<ReverseLookupRegistryV1>(@aptos_names_v2), error::invalid_state(EREVERSE_LOOKUP_NOT_INITIALIZED));
+        let registry = &borrow_global_mut<ReverseLookupRegistryV1>(@aptos_names_v2).registry;
         if (table::contains(registry, account_addr)) {
             let token_addr = *table::borrow(registry, account_addr);
             option::some(token_addr)
@@ -733,8 +733,8 @@ module aptos_names::domains {
         let record_obj = object::address_to_object<NameRecordV2>(token_addr);
         assert!(object::owns(record_obj, account_addr), error::permission_denied(ENOT_AUTHORIZED));
 
-        assert!(exists<ReverseLookupRegistryV1>(@aptos_names), error::invalid_state(EREVERSE_LOOKUP_NOT_INITIALIZED));
-        let registry = &mut borrow_global_mut<ReverseLookupRegistryV1>(@aptos_names).registry;
+        assert!(exists<ReverseLookupRegistryV1>(@aptos_names_v2), error::invalid_state(EREVERSE_LOOKUP_NOT_INITIALIZED));
+        let registry = &mut borrow_global_mut<ReverseLookupRegistryV1>(@aptos_names_v2).registry;
         table::upsert(registry, account_addr, token_addr);
 
         emit_set_reverse_lookup_event_v1(
@@ -753,8 +753,8 @@ module aptos_names::domains {
         };
         let token_addr = *option::borrow(&maybe_reverse_lookup);
         let record = borrow_global<NameRecordV2>(token_addr);
-        assert!(exists<ReverseLookupRegistryV1>(@aptos_names), error::invalid_state(EREVERSE_LOOKUP_NOT_INITIALIZED));
-        let registry = &mut borrow_global_mut<ReverseLookupRegistryV1>(@aptos_names).registry;
+        assert!(exists<ReverseLookupRegistryV1>(@aptos_names_v2), error::invalid_state(EREVERSE_LOOKUP_NOT_INITIALIZED));
+        let registry = &mut borrow_global_mut<ReverseLookupRegistryV1>(@aptos_names_v2).registry;
         table::remove(registry, account_addr);
         emit_set_reverse_lookup_event_v1(
             record.subdomain_name,
@@ -795,7 +795,7 @@ module aptos_names::domains {
         };
 
         event::emit_event<SetNameAddressEventV1>(
-            &mut borrow_global_mut<SetNameAddressEventsV1>(@aptos_names).set_name_events,
+            &mut borrow_global_mut<SetNameAddressEventsV1>(@aptos_names_v2).set_name_events,
             event,
         );
     }
@@ -811,9 +811,9 @@ module aptos_names::domains {
             target_address,
         };
 
-        assert!(exists<ReverseLookupRegistryV1>(@aptos_names), error::invalid_state(EREVERSE_LOOKUP_NOT_INITIALIZED));
+        assert!(exists<ReverseLookupRegistryV1>(@aptos_names_v2), error::invalid_state(EREVERSE_LOOKUP_NOT_INITIALIZED));
         event::emit_event<SetReverseLookupEventV1>(
-            &mut borrow_global_mut<SetReverseLookupEventsV1>(@aptos_names).set_reverse_lookup_events,
+            &mut borrow_global_mut<SetReverseLookupEventsV1>(@aptos_names_v2).set_reverse_lookup_events,
             event,
         );
     }
@@ -845,18 +845,18 @@ module aptos_names::domains {
 
     #[test_only]
     public fun get_set_name_address_event_v1_count(): u64 acquires SetNameAddressEventsV1 {
-        event::counter(&borrow_global<SetNameAddressEventsV1>(@aptos_names).set_name_events)
+        event::counter(&borrow_global<SetNameAddressEventsV1>(@aptos_names_v2).set_name_events)
     }
 
     #[test_only]
     public fun get_register_name_event_v1_count(): u64 acquires RegisterNameEventsV1 {
-        event::counter(&borrow_global<RegisterNameEventsV1>(@aptos_names).register_name_events)
+        event::counter(&borrow_global<RegisterNameEventsV1>(@aptos_names_v2).register_name_events)
     }
 
     #[test_only]
     public fun get_set_reverse_lookup_event_v1_count(): u64 acquires SetReverseLookupEventsV1 {
-        assert!(exists<ReverseLookupRegistryV1>(@aptos_names), error::invalid_state(EREVERSE_LOOKUP_NOT_INITIALIZED));
-        event::counter(&borrow_global<SetReverseLookupEventsV1>(@aptos_names).set_reverse_lookup_events)
+        assert!(exists<ReverseLookupRegistryV1>(@aptos_names_v2), error::invalid_state(EREVERSE_LOOKUP_NOT_INITIALIZED));
+        event::counter(&borrow_global<SetReverseLookupEventsV1>(@aptos_names_v2).set_reverse_lookup_events)
     }
 
     #[test(aptos = @0x1)]

--- a/core_v2/sources/price_model.move
+++ b/core_v2/sources/price_model.move
@@ -1,5 +1,5 @@
-module aptos_names::price_model {
-    use aptos_names::config;
+module aptos_names_v2::price_model {
+    use aptos_names_v2::config;
     use aptos_std::math64;
     use std::error;
 
@@ -35,9 +35,9 @@ module aptos_names::price_model {
         config::subdomain_price()
     }
 
-    #[test(myself = @aptos_names, framework = @0x1)]
+    #[test(myself = @aptos_names_v2, framework = @0x1)]
     fun test_price_for_domain_v1(myself: &signer, framework: &signer) {
-        use aptos_names::config;
+        use aptos_names_v2::config;
         use aptos_framework::aptos_coin::AptosCoin;
         use aptos_framework::coin;
         use aptos_framework::account;
@@ -48,7 +48,7 @@ module aptos_names::price_model {
 
         config::initialize_aptoscoin_for(framework);
         coin::register<AptosCoin>(myself);
-        config::initialize_v1(myself, @aptos_names, @aptos_names);
+        config::initialize_v1(myself, @aptos_names_v2, @aptos_names_v2);
 
         config::set_subdomain_price(myself, config::octas() / 5);
         config::set_domain_price_for_length(myself, (100 * config::octas()), 2);
@@ -88,7 +88,7 @@ module aptos_names::price_model {
         expected_price: u64,
     }
 
-    #[test(myself = @aptos_names, framework = @0x1)]
+    #[test(myself = @aptos_names_v2, framework = @0x1)]
     fun test_scale_price_for_years(myself: &signer, framework: &signer) {
         use aptos_framework::account;
         use std::signer;

--- a/core_v2/sources/subdomain_e2e_tests.move
+++ b/core_v2/sources/subdomain_e2e_tests.move
@@ -1,16 +1,16 @@
 #[test_only]
-module aptos_names::subdomain_e2e_tests {
+module aptos_names_v2::subdomain_e2e_tests {
     use aptos_framework::timestamp;
-    use aptos_names::domains;
-    use aptos_names::test_utils;
-    use aptos_names::test_helper;
+    use aptos_names_v2::domains;
+    use aptos_names_v2::test_utils;
+    use aptos_names_v2::test_helper;
     use std::option;
     use std::signer;
     use std::vector;
-    use aptos_names::time_helper;
+    use aptos_names_v2::time_helper;
 
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun happy_path_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -48,7 +48,7 @@ module aptos_names::subdomain_e2e_tests {
         test_helper::clear_name_address(rando, option::some(test_helper::subdomain_name()), test_helper::domain_name());
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun names_are_registerable_after_expiry_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -110,8 +110,8 @@ module aptos_names::subdomain_e2e_tests {
         test_helper::register_name(rando, option::some(test_helper::subdomain_name()), test_helper::domain_name(), timestamp::now_seconds() + test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 3, vector::empty<u8>());
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 196611, location = aptos_names::domains)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[expected_failure(abort_code = 196611, location = aptos_names_v2::domains)]
     fun dont_allow_double_subdomain_registrations_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -123,8 +123,8 @@ module aptos_names::subdomain_e2e_tests {
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327689, location = aptos_names::domains)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[expected_failure(abort_code = 327689, location = aptos_names_v2::domains)]
     fun dont_allow_rando_to_set_subdomain_address_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -134,11 +134,11 @@ module aptos_names::subdomain_e2e_tests {
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
         // Ensure we can't clear it as a rando. The expected target address doesn't matter as it won't get hit
-        test_helper::set_name_address(rando, option::some(test_helper::subdomain_name()), test_helper::domain_name(), @aptos_names);
+        test_helper::set_name_address(rando, option::some(test_helper::subdomain_name()), test_helper::domain_name(), @aptos_names_v2);
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327689, location = aptos_names::domains)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[expected_failure(abort_code = 327689, location = aptos_names_v2::domains)]
     fun dont_allow_rando_to_clear_subdomain_address_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -149,10 +149,10 @@ module aptos_names::subdomain_e2e_tests {
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
         test_helper::set_name_address(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), signer::address_of(user));
         // Ensure we can't clear it as a rando. The expected target address doesn't matter as it won't get hit
-        test_helper::set_name_address(rando, option::some(test_helper::subdomain_name()), test_helper::domain_name(), @aptos_names);
+        test_helper::set_name_address(rando, option::some(test_helper::subdomain_name()), test_helper::domain_name(), @aptos_names_v2);
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun admin_can_force_set_subdomain_address_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -170,8 +170,8 @@ module aptos_names::subdomain_e2e_tests {
         assert!(target_address == option::some(rando_addr), 33);
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327681, location = aptos_names::config)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[expected_failure(abort_code = 327681, location = aptos_names_v2::config)]
     fun rando_cant_force_set_subdomain_address_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -188,7 +188,7 @@ module aptos_names::subdomain_e2e_tests {
         domains::force_set_subdomain_address(rando, test_helper::subdomain_name(), test_helper::domain_name(), rando_addr);
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun admin_can_force_seize_subdomain_name_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -209,7 +209,7 @@ module aptos_names::subdomain_e2e_tests {
         assert!(time_helper::seconds_to_years(expiration_time_sec) == 1, time_helper::seconds_to_years(expiration_time_sec));
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun admin_can_force_create_subdomain_name_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -228,8 +228,8 @@ module aptos_names::subdomain_e2e_tests {
         assert!(time_helper::seconds_to_years(expiration_time_sec) == 1, time_helper::seconds_to_years(expiration_time_sec));
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 131086, location = aptos_names::domains)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[expected_failure(abort_code = 131086, location = aptos_names_v2::domains)]
     fun admin_cant_force_create_subdomain_more_than_domain_time_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -242,8 +242,8 @@ module aptos_names::subdomain_e2e_tests {
         domains::force_create_or_seize_name(myself, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs() + 1);
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327681, location = aptos_names::config)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[expected_failure(abort_code = 327681, location = aptos_names_v2::config)]
     fun rando_cant_force_seize_subdomain_name_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -259,8 +259,8 @@ module aptos_names::subdomain_e2e_tests {
         domains::force_create_or_seize_name(rando, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::two_hundred_year_secs());
     }
 
-    #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
-    #[expected_failure(abort_code = 327681, location = aptos_names::config)]
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[expected_failure(abort_code = 327681, location = aptos_names_v2::config)]
     fun rando_cant_force_create_subdomain_name_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);

--- a/core_v2/sources/test_helper.move
+++ b/core_v2/sources/test_helper.move
@@ -1,14 +1,14 @@
 #[test_only]
-module aptos_names::test_helper {
+module aptos_names_v2::test_helper {
     use aptos_framework::account;
     use aptos_framework::aptos_coin::AptosCoin;
     use aptos_framework::coin;
     use aptos_framework::timestamp;
-    use aptos_names::config;
-    use aptos_names::domains;
-    use aptos_names::price_model;
-    use aptos_names::test_utils;
-    use aptos_names::time_helper;
+    use aptos_names_v2::config;
+    use aptos_names_v2::domains;
+    use aptos_names_v2::price_model;
+    use aptos_names_v2::test_utils;
+    use aptos_names_v2::time_helper;
     use std::option::{Self, Option};
     use std::signer;
     use std::string::{Self, String};
@@ -47,7 +47,7 @@ module aptos_names::test_helper {
     }
 
     public fun e2e_test_setup(myself: &signer, user: signer, aptos: &signer, rando: signer, foundation: &signer): vector<signer> {
-        account::create_account_for_test(@aptos_names);
+        account::create_account_for_test(@aptos_names_v2);
         let new_accounts = setup_and_fund_accounts(aptos, foundation, vector[user, rando]);
         timestamp::set_time_has_started_for_testing(aptos);
         domains::init_module_for_test(myself);

--- a/core_v2/sources/test_utils.move
+++ b/core_v2/sources/test_utils.move
@@ -1,5 +1,5 @@
 #[test_only]
-module aptos_names::test_utils {
+module aptos_names_v2::test_utils {
 
     use std::string::{Self, String};
     use aptos_std::debug;

--- a/core_v2/sources/time_helper.move
+++ b/core_v2/sources/time_helper.move
@@ -1,4 +1,4 @@
-module aptos_names::time_helper {
+module aptos_names_v2::time_helper {
 
     const SECONDS_PER_MINUTE: u64 = 60;
     const SECONDS_PER_HOUR: u64 = 60 * 60;

--- a/core_v2/sources/token_helper.move
+++ b/core_v2/sources/token_helper.move
@@ -1,7 +1,7 @@
-module aptos_names::token_helper {
-    friend aptos_names::domains;
+module aptos_names_v2::token_helper {
+    friend aptos_names_v2::domains;
 
-    use aptos_names::utf8_utils;
+    use aptos_names_v2::utf8_utils;
     use std::option::{Self, Option};
     use std::string::{Self, String};
 

--- a/core_v2/sources/utf8_utils.move
+++ b/core_v2/sources/utf8_utils.move
@@ -1,4 +1,4 @@
-module aptos_names::utf8_utils {
+module aptos_names_v2::utf8_utils {
 
     use std::string::{Self, String};
     use std::vector;

--- a/core_v2/sources/verify.move
+++ b/core_v2/sources/verify.move
@@ -1,11 +1,11 @@
-module aptos_names::verify {
+module aptos_names_v2::verify {
     use std::string;
     use aptos_framework::account;
     use aptos_framework::chain_id;
     use aptos_std::ed25519;
-    use aptos_names::config;
+    use aptos_names_v2::config;
 
-    friend aptos_names::domains;
+    friend aptos_names_v2::domains;
 
     struct RegisterDomainProofChallenge has drop {
         sequence_number: u64,


### PR DESCRIPTION
### Description

Rename the package so we can import `aptos_names` package without package name conflicts

### Test Plan

Pass unit tests