### PR TITLE
[ans] adding renewal functions to domain/subdomain

### DIFF
--- a/core_v2/sources/domains.move
+++ b/core_v2/sources/domains.move
@@ -660,19 +660,15 @@ module aptos_names_v2::domains {
             assert!(false, error::invalid_state(ENAME_NOT_EXIST));
         };
         let record = get_record(domain_name, subdomain_name);
-        time_is_expired(record.expiration_time_sec)
-    }
-
-    /// Returns true if the name is registered, and is expired.
-    /// If the name does not exist, raises an error
-    public fun name_is_expired_new(
-        subdomain_name: Option<String>,
-        domain_name: String
-    ): bool acquires CollectionCapabilityV2, NameRecordV2 {
-        if (!name_is_registered(subdomain_name, domain_name)) {
-            assert!(false, error::invalid_state(ENAME_NOT_EXIST));
+        // check the auto-renew flag
+        if (option::is_some(&record.subdomain_ext)) {
+            let subdomain_ext = option::borrow(&record.subdomain_ext);
+            if (subdomain_ext.use_domain_expiration_sec) {
+                // refer to the expiration date of the domain
+                let domain_record = get_record(domain_name, option::none());
+                return time_is_expired(domain_record.expiration_time_sec)
+            }
         };
-        let record = get_record(domain_name, subdomain_name);
         time_is_expired(record.expiration_time_sec)
     }
 

--- a/core_v2/sources/subdomain_e2e_tests.move
+++ b/core_v2/sources/subdomain_e2e_tests.move
@@ -9,6 +9,7 @@ module aptos_names_v2::subdomain_e2e_tests {
     use std::vector;
     use aptos_names_v2::time_helper;
 
+    const MAX_REMAINING_TIME_FOR_RENEWAL_SEC: u64 = 15552000;
 
     #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun happy_path_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
@@ -49,6 +50,82 @@ module aptos_names_v2::subdomain_e2e_tests {
     }
 
     #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    fun renew_domain_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
+        let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
+        let user = vector::borrow(&users, 0);
+
+        // Register the domain
+        test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
+        let (expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::none(), test_helper::domain_name());
+
+        // Set the time is early than max remaining time for renewal from expiration time
+        timestamp::update_global_time_for_test_secs(expiration_time_sec - MAX_REMAINING_TIME_FOR_RENEWAL_SEC - 5);
+        assert!(!domains::is_domain_in_renewal_window(test_helper::domain_name()), 1);
+
+        timestamp::update_global_time_for_test_secs(expiration_time_sec - MAX_REMAINING_TIME_FOR_RENEWAL_SEC + 5);
+        assert!(domains::is_domain_in_renewal_window(test_helper::domain_name()), 2);
+
+        // Renew the domain
+        domains::renew_domain(user, test_helper::domain_name(), 1);
+
+        // Ensure the domain is still registered after the original expiration time
+        timestamp::update_global_time_for_test_secs(expiration_time_sec + 5);
+        assert!(domains::name_is_registered(option::none(), test_helper::domain_name()), 4);
+
+        let (new_expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::none(), test_helper::domain_name());
+        // Ensure the domain is still expired after the new expiration time
+        timestamp::update_global_time_for_test_secs(new_expiration_time_sec + 5);
+        assert!(domains::name_is_expired(option::none(), test_helper::domain_name()), 5);
+    }
+
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    fun auto_renew_subdomain_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
+        let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
+        let user = vector::borrow(&users, 0);
+        // Register the domain
+        test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
+
+        // Register a subdomain!
+        test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), timestamp::now_seconds() + test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
+        // The subdomain auto-renewal policy is true by default
+        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()), 2);
+
+        // Renew the domain (and the subdomain should be auto renewed)
+        let (original_expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::some(test_helper::subdomain_name()), test_helper::domain_name());
+        timestamp::update_global_time_for_test_secs(original_expiration_time_sec - 5);
+        domains::renew_domain(user, test_helper::domain_name(), 1);
+        // Set the time past the domain's expiration time
+        timestamp::update_global_time_for_test_secs(original_expiration_time_sec + 5);
+        // Both domain and subdomain are not expired
+        assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 80);
+        assert!(!domains::name_is_expired(option::some(test_helper::subdomain_name()), test_helper::domain_name()), 80);
+     }
+
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    fun manual_renew_subdomain_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
+        let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
+        let user = vector::borrow(&users, 0);
+        // Register the domain
+        test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
+
+        // Register a subdomain!
+        test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), timestamp::now_seconds() + test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
+        domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), false);
+        assert!(!domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()), 2);
+
+        // Set the time past the domain's expiration time
+        let (expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::some(test_helper::subdomain_name()), test_helper::domain_name());
+        // Renew the domain before it's expired
+        timestamp::update_global_time_for_test_secs(expiration_time_sec - 5);
+        domains::renew_domain(user, test_helper::domain_name(), 1);
+        // Set the time past the domain's expiration time
+        timestamp::update_global_time_for_test_secs(expiration_time_sec + 5);
+        // Ensure the subdomain is still expired after domain renewal
+        assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 80);
+        assert!(domains::name_is_expired(option::some(test_helper::subdomain_name()), test_helper::domain_name()), 80);
+    }
+
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun names_are_registerable_after_expiry_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);
@@ -59,6 +136,7 @@ module aptos_names_v2::subdomain_e2e_tests {
 
         // Register a subdomain!
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), timestamp::now_seconds() + test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
+        // Set the subdomain auto-renewal policy to false
         domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), false);
 
         // Set the time past the domain's expiration time

--- a/core_v2/sources/subdomain_e2e_tests.move
+++ b/core_v2/sources/subdomain_e2e_tests.move
@@ -59,6 +59,7 @@ module aptos_names_v2::subdomain_e2e_tests {
 
         // Register a subdomain!
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), timestamp::now_seconds() + test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
+        domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), false);
 
         // Set the time past the domain's expiration time
         let (expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::some(test_helper::subdomain_name()), test_helper::domain_name());


### PR DESCRIPTION
## description
In this PR I changed the `struct NameRecord` to the one we agreed on. and add 
1. renewal function for domain. 
2. renewal function for subdomain (manual set the date when the flag `use_domain_expiration_sec` is false
3. setter function for subdomain to switch the flag `use_domain_expiration_sec`

## test
run `aptos move test` to make sure it passes all the tests