### PR TITLE
put all subdomains in 1 collection

### DIFF
--- a/core_v2/Move.toml
+++ b/core_v2/Move.toml
@@ -3,9 +3,9 @@ name = 'aptos_names_v2'
 version = '1.0.0'
 
 [addresses]
-aptos_names_v2 = "_"
-aptos_names_admin = "_"
-aptos_names_funds = "_"
+aptos_names_v2 = "0x123"
+aptos_names_admin = "0x123"
+aptos_names_funds = "0x123"
 
 [dependencies.aptos_names]
 local = "../core"

--- a/core_v2/Move.toml
+++ b/core_v2/Move.toml
@@ -3,9 +3,9 @@ name = 'aptos_names_v2'
 version = '1.0.0'
 
 [addresses]
-aptos_names_v2 = "0x123"
-aptos_names_admin = "0x123"
-aptos_names_funds = "0x123"
+aptos_names_v2 = "_"
+aptos_names_admin = "_"
+aptos_names_funds = "_"
 
 [dependencies.aptos_names]
 local = "../core"

--- a/core_v2/sources/config.move
+++ b/core_v2/sources/config.move
@@ -38,7 +38,8 @@ module aptos_names_v2::config {
     const DOMAIN_TYPE: vector<u8> = b"domain";
     const SUBDOMAIN_TYPE: vector<u8> = b"subdomain";
 
-    const COLLECTION_NAME: vector<u8> = b"Aptos Names V2";
+    const DOMAIN_COLLECTION_NAME_V1: vector<u8> = b"Aptos Domain Names V1";
+    const SUBDOMAIN_COLLECTION_NAME_V1: vector<u8> = b"Aptos Subdomain Names V1";
 
     /// Raised if the signer is not authorized to perform an action
     const ENOT_AUTHORIZED: u64 = 1;
@@ -144,8 +145,12 @@ module aptos_names_v2::config {
         return string::utf8(SUBDOMAIN_TYPE)
     }
 
-    public fun collection_name(): String {
-        return string::utf8(COLLECTION_NAME)
+    public fun domain_collection_name_v1(): String {
+        return string::utf8(DOMAIN_COLLECTION_NAME_V1)
+    }
+
+    public fun subdomain_collection_name_v1(): String {
+        return string::utf8(SUBDOMAIN_COLLECTION_NAME_V1)
     }
 
     public fun domain_price_for_length(domain_length: u64): u64 acquires ConfigurationV1 {

--- a/core_v2/sources/domains.move
+++ b/core_v2/sources/domains.move
@@ -96,6 +96,8 @@ module aptos_names_v2::domains {
         expiration_time_sec: u64,
         target_address: Option<address>,
         transfer_ref: object::TransferRef,
+        // Currently unused, but may be used in the future to extend with more metadata
+        extend_ref: object::ExtendRef,
         // Only present for subdomain
         subdomain_ext: Option<SubdomainExt>,
     }
@@ -331,6 +333,7 @@ module aptos_names_v2::domains {
             expiration_time_sec,
             target_address: option::none(),
             transfer_ref: object::generate_transfer_ref(&constructor_ref),
+            extend_ref: object::generate_extend_ref(&constructor_ref),
             subdomain_ext,
         };
         move_to(&token_signer, record);

--- a/core_v2/sources/domains.move
+++ b/core_v2/sources/domains.move
@@ -4,7 +4,7 @@ module aptos_names_v2::domains {
     use aptos_framework::aptos_coin::AptosCoin;
     use aptos_framework::coin;
     use aptos_framework::event;
-    use aptos_framework::object::{Self, Object};
+    use aptos_framework::object::{Self, Object, ConstructorRef};
     use aptos_framework::timestamp;
     use aptos_names_v2::config;
     use aptos_names_v2::migrate_helper;
@@ -223,9 +223,15 @@ module aptos_names_v2::domains {
         domain_name: String,
         subdomain_name: Option<String>,
     ): address acquires CollectionCapabilityV2 {
+        let collection_name: String;
+        if (option::is_some(&subdomain_name)) {
+            collection_name = domain_name;
+        } else {
+            collection_name = config::collection_name_v1();
+        };
         token::create_token_address(
             &get_token_signer_address(),
-            &config::collection_name(),
+            &collection_name,
             &token_helper::get_fully_qualified_domain_name(subdomain_name, domain_name),
         )
     }
@@ -234,9 +240,15 @@ module aptos_names_v2::domains {
         domain_name: String,
         subdomain_name: Option<String>,
     ): address acquires CollectionCapabilityV2 {
+        let collection_name: String;
+        if (option::is_some(&subdomain_name)) {
+            collection_name = domain_name;
+        } else {
+            collection_name = config::collection_name_v1();
+        };
         token::create_token_address(
             &get_token_signer_address(),
-            &config::collection_name(),
+            &collection_name,
             &token_helper::get_fully_qualified_domain_name(subdomain_name, domain_name),
         )
     }
@@ -278,31 +290,54 @@ module aptos_names_v2::domains {
         domain_name: String,
         subdomain_name: Option<String>,
         expiration_time_sec: u64,
-    ) acquires CollectionCapabilityV2 {
+    ) acquires CollectionCapabilityV2, NameRecordV2 {
         let name = token_helper::get_fully_qualified_domain_name(subdomain_name, domain_name);
         let description = config::tokendata_description();
         let uri: string::String = config::tokendata_url_prefix();
         string::append(&mut uri, name);
-        let constructor_ref = token::create_named_token(
-            &get_token_signer(),
-            config::collection_name(),
-            description,
-            name,
-            option::none(),
-            uri,
-        );
-        let token_signer = object::generate_signer(&constructor_ref);
 
         let subdomain_ext: Option<SubdomainExt>;
+        let constructor_ref: ConstructorRef;
+        let token_signer: signer;
+
+        // creating subdomain
         if (option::is_some(&subdomain_name)) {
+            let domain_record = get_record(domain_name, option::none());
+            constructor_ref = token::create_named_token(
+                &object::generate_signer_for_extending(&domain_record.extend_ref),
+                domain_name,
+                description,
+                name,
+                option::none(),
+                uri,
+            );
+            token_signer = object::generate_signer(&constructor_ref);
             subdomain_ext = option::some(SubdomainExt {
                 subdomain_name: option::extract(&mut subdomain_name),
-                // TODO: use_domain_expiration_sec should be passed in as a param
-                // Now by default subdomain follow domain's expiration
-                use_domain_expiration_sec: true,
-            })
-        } else {
+                use_domain_expiration_sec: true, // by default subdomain follow domain's expiration
+            });
+        }
+        // creating domain
+        else {
+            constructor_ref = token::create_named_token(
+                &get_token_signer(),
+                config::collection_name_v1(),
+                description,
+                name,
+                option::none(),
+                uri,
+            );
+            token_signer = object::generate_signer(&constructor_ref);
             subdomain_ext = option::none<SubdomainExt>();
+            // create subdomain collection
+            // TODO: revisit description, name and uri
+            collection::create_unlimited_collection(
+                &token_signer,
+                domain_name,
+                domain_name,
+                option::none(),
+                utf8(COLLECTION_URI),
+            );
         };
         let record = NameRecordV2 {
             domain_name,

--- a/core_v2/sources/domains.move
+++ b/core_v2/sources/domains.move
@@ -223,15 +223,9 @@ module aptos_names_v2::domains {
         domain_name: String,
         subdomain_name: Option<String>,
     ): address acquires CollectionCapabilityV2 {
-        let collection_name: String;
-        if (option::is_some(&subdomain_name)) {
-            collection_name = domain_name;
-        } else {
-            collection_name = config::collection_name_v1();
-        };
         token::create_token_address(
             &get_token_signer_address(),
-            &collection_name,
+            &get_collection_name(domain_name, subdomain_name),
             &token_helper::get_fully_qualified_domain_name(subdomain_name, domain_name),
         )
     }
@@ -240,15 +234,9 @@ module aptos_names_v2::domains {
         domain_name: String,
         subdomain_name: Option<String>,
     ): address acquires CollectionCapabilityV2 {
-        let collection_name: String;
-        if (option::is_some(&subdomain_name)) {
-            collection_name = domain_name;
-        } else {
-            collection_name = config::collection_name_v1();
-        };
         token::create_token_address(
             &get_token_signer_address(),
-            &collection_name,
+            &get_collection_name(domain_name, subdomain_name),
             &token_helper::get_fully_qualified_domain_name(subdomain_name, domain_name),
         )
     }
@@ -280,6 +268,14 @@ module aptos_names_v2::domains {
             option::some(subdomain_ext.subdomain_name)
         } else {
             option::none<String>()
+        }
+    }
+
+    inline fun get_collection_name(domain_name: String, subdomain_name: Option<String>): String {
+        if (option::is_some(&subdomain_name)) {
+            domain_name
+        } else {
+            config::collection_name_v1()
         }
     }
 


### PR DESCRIPTION
Instead of putting all domains and subdomains in 1 collection, we create a collection only for subdomains so projects integrating ANS can easily tell the difference between domain and subdomain by looking at their collection.