### PR TITLE
[ans] set subdomain expiration 

### DIFF
--- a/core_v2/sources/domains.move
+++ b/core_v2/sources/domains.move
@@ -73,7 +73,9 @@ module aptos_names_v2::domains {
     const ENOT_A_SUBDOMAIN: u64 = 22;
     /// The domain expiration, even after migration extension, is past now.
     const EMIGRATION_ALREADY_EXPIRED: u64 = 23;
+    /// The subdomain expiration can be set any date before the domain expiration
     const ESUBDOMAIN_EXPIRATION_PASS_DOMAIN_EXPIRATION: u64 = 24;
+    /// The duration must be whole years
     const EDURATION_MUST_BE_WHOLE_YEARS: u64 = 25;
 
     /// Tokens require a signer to create, so this is the signer for the collection

--- a/core_v2/sources/domains.move
+++ b/core_v2/sources/domains.move
@@ -29,6 +29,7 @@ module aptos_names_v2::domains {
     const MAX_REMAINING_TIME_FOR_RENEWAL_SEC: u64 = 15552000;
     /// 2024/03/07 23:59:59
     const AUTO_RENEWAL_EXPIRATION_CUTOFF_SEC: u64 = 1709855999;
+    const SECONDS_PER_YEAR: u64 = 60 * 60 * 24 * 365;
 
     /// The Naming Service contract is not enabled
     const ENOT_ENABLED: u64 = 1;
@@ -72,6 +73,8 @@ module aptos_names_v2::domains {
     const ENOT_A_SUBDOMAIN: u64 = 22;
     /// The domain expiration, even after migration extension, is past now.
     const EMIGRATION_ALREADY_EXPIRED: u64 = 23;
+    const ESUBDOMAIN_EXPIRATION_PASS_DOMAIN_EXPIRATION: u64 = 24;
+    const EDURATION_MUST_BE_WHOLE_YEARS: u64 = 25;
 
     /// Tokens require a signer to create, so this is the signer for the collection
     struct CollectionCapabilityV2 has key, drop {
@@ -280,14 +283,14 @@ module aptos_names_v2::domains {
         domain_name: String,
         subdomain_name: Option<String>,
     ): &NameRecordV2 acquires CollectionCapabilityV2, NameRecordV2 {
-        borrow_global(token_addr_inline(domain_name, subdomain_name))
+        borrow_global<NameRecordV2>(token_addr_inline(domain_name, subdomain_name))
     }
 
     inline fun get_record_mut(
         domain_name: String,
         subdomain_name: Option<String>,
     ): &mut NameRecordV2 acquires CollectionCapabilityV2, NameRecordV2 {
-        borrow_global_mut(token_addr_inline(domain_name, subdomain_name))
+        borrow_global_mut<NameRecordV2>(token_addr_inline(domain_name, subdomain_name))
     }
 
     inline fun extract_subdomain_name(record: &NameRecordV2): Option<String> {
@@ -359,24 +362,17 @@ module aptos_names_v2::domains {
     fun register_domain_generic(
         sign: &signer,
         domain_name: String,
-        num_years: u8
+        registration_duration_secs: u64,
     ) acquires CollectionCapabilityV2, NameRecordV2, RegisterNameEventsV1, ReverseRecord, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
-        assert!(config::is_enabled(), error::unavailable(ENOT_ENABLED));
-        assert!(
-            num_years > 0 && num_years <= config::max_number_of_years_registered(),
-            error::out_of_range(EINVALID_NUMBER_YEARS)
-        );
+        validate_registration_duration(registration_duration_secs);
 
         let subdomain_name = option::none<String>();
 
         assert!(name_is_registerable(subdomain_name, domain_name), error::invalid_state(ENAME_NOT_AVAILABLE));
 
-        // Conver the num_years to its seconds representation for the inner method
-        let registration_duration_secs: u64 = time_helper::years_to_seconds((num_years as u64));
-
         let length = validate_name_string(domain_name);
 
-        let price = price_model::price_for_domain_v1(length, num_years);
+        let price = price_model::price_for_domain_v1(length, registration_duration_secs);
         coin::transfer<AptosCoin>(sign, config::fund_destination_address(), price);
 
         register_name_internal(sign, subdomain_name, domain_name, registration_duration_secs, price);
@@ -387,21 +383,21 @@ module aptos_names_v2::domains {
     public entry fun register_domain(
         sign: &signer,
         domain_name: String,
-        num_years: u8
+        registration_duration_secs: u64,
     ) acquires CollectionCapabilityV2, NameRecordV2, RegisterNameEventsV1, ReverseRecord, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         assert!(config::unrestricted_mint_enabled(), error::permission_denied(EVALID_SIGNATURE_REQUIRED));
-        register_domain_generic(sign, domain_name, num_years);
+        register_domain_generic(sign, domain_name, registration_duration_secs);
     }
 
     public entry fun register_domain_with_signature(
         sign: &signer,
         domain_name: String,
-        num_years: u8,
+        registration_duration_secs: u64,
         signature: vector<u8>
     ) acquires CollectionCapabilityV2, NameRecordV2, RegisterNameEventsV1, ReverseRecord, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
         let account_address = signer::address_of(sign);
         verify::assert_register_domain_signature_verifies(signature, account_address, domain_name);
-        register_domain_generic(sign, domain_name, num_years);
+        register_domain_generic(sign, domain_name, registration_duration_secs);
     }
 
     /// A wrapper around `register_name` as an entry function.
@@ -593,25 +589,25 @@ module aptos_names_v2::domains {
     public entry fun renew_domain(
         sign: &signer,
         domain_name: String,
-        num_years: u8,
+        registration_duration_secs: u64,
     ) acquires CollectionCapabilityV2, NameRecordV2, RenewNameEventsV1 {
         // check the domain eligibility
         let length = validate_name_string(domain_name);
 
+        validate_registration_duration(registration_duration_secs);
         assert!(is_domain_in_renewal_window(domain_name), error::invalid_state(EDOMAIN_NOT_AVAILABLE_TO_RENEW));
-        let price = price_model::price_for_domain_v1(length, num_years);
-        renew_domain_internal(sign, domain_name, num_years, price);
+        let price = price_model::price_for_domain_v1(length, registration_duration_secs);
+        renew_domain_internal(sign, domain_name, registration_duration_secs, price);
     }
 
     fun renew_domain_internal(
         sign: &signer,
         domain_name: String,
-        num_years: u8,
+        registration_duration_secs: u64,
         price: u64,
     ) acquires CollectionCapabilityV2, NameRecordV2, RenewNameEventsV1 {
         let record = get_record_mut(domain_name, option::none());
-        let registration_duration_secs = time_helper::years_to_seconds((num_years as u64));
-        record.expiration_time_sec = record.expiration_time_sec + registration_duration_secs;
+        record.expiration_time_sec = timestamp::now_seconds() + registration_duration_secs;
 
         // pay the price
         coin::transfer<AptosCoin>(sign, config::fund_destination_address(), price);
@@ -624,6 +620,18 @@ module aptos_names_v2::domains {
                 registration_fee_octas: price,
                 expiration_time_secs: record.expiration_time_sec,
             },
+        );
+    }
+
+    fun validate_registration_duration(
+        registration_duration_secs: u64,
+    ) {
+        assert!(registration_duration_secs % SECONDS_PER_YEAR == 0, error::invalid_argument(EDURATION_MUST_BE_WHOLE_YEARS));
+
+        let num_years = (time_helper::seconds_to_years(registration_duration_secs) as u8);
+        assert!(
+            num_years > 0 && num_years <= config::max_number_of_years_registered(),
+            error::out_of_range(EINVALID_NUMBER_YEARS)
         );
     }
 
@@ -651,24 +659,30 @@ module aptos_names_v2::domains {
     }
 
     /// this is for domain owner to update subdomain expiration time
-    public fun renew_subdomain_as_domain_owner(
+    public fun set_subdomain_expiration_as_domain_owner(
         sign: &signer,
-        subdomain_name: String,
         domain_name: String,
-        registration_duration_secs: u64,
-    ) acquires CollectionCapabilityV2, NameRecordV2{
+        subdomain_name: String,
+        expiration_time_sec: u64,
+    ) acquires CollectionCapabilityV2, NameRecordV2 {
         validate_subdomain_to_renew(sign, subdomain_name, domain_name);
-
-        let record = get_record_mut(domain_name, option::some(subdomain_name));
-        assert!(option::is_some(&record.subdomain_ext), error::invalid_state(ENOT_A_SUBDOMAIN));
+        // check if the expiration time is valid
+        let domain_record = get_record(domain_name, option::none());
+        assert!(
+            domain_record.expiration_time_sec >= expiration_time_sec,
+            error::invalid_state(ESUBDOMAIN_EXPIRATION_PASS_DOMAIN_EXPIRATION)
+        );
 
         // check the auto-renew flag
-        let subdomain_ext = option::borrow(&record.subdomain_ext);
-        if (subdomain_ext.use_domain_expiration_sec) {
-            assert!(false, error::invalid_state(ESUBDOMAIN_IS_AUTO_RENEW));
-        };
+        let record = get_record_mut(domain_name, option::some(subdomain_name));
+        assert!(option::is_some(&record.subdomain_ext), error::invalid_state(ENOT_A_SUBDOMAIN));
+            let subdomain_ext = option::borrow(&record.subdomain_ext);
+            if (subdomain_ext.use_domain_expiration_sec) {
+                assert!(false, error::invalid_state(ESUBDOMAIN_IS_AUTO_RENEW));
+            };
+
         // manually set the expiration date
-        record.expiration_time_sec = record.expiration_time_sec + registration_duration_secs;
+        record.expiration_time_sec = expiration_time_sec;
     }
 
     public fun set_subdomain_renewal_policy(

--- a/core_v2/sources/price_model.move
+++ b/core_v2/sources/price_model.move
@@ -6,6 +6,7 @@ module aptos_names_v2::price_model {
 
     /// The domain length is too short- currently the minimum is 2 characters
     const EDOMAIN_TOO_SHORT: u64 = 1;
+    const SECONDS_PER_YEAR: u64 = 60 * 60 * 24 * 365;
 
     /// The longer the name is registered for, the more expensive it is per year.
     /// The curve is exponential, with every year costing more than the previous
@@ -24,9 +25,10 @@ module aptos_names_v2::price_model {
     }
 
     /// There is a fixed cost per each tier of domain names, from 2 to >=6, and it also scales exponentially with number of years to register
-    public fun price_for_domain_v1(domain_length: u64, registration_years: u8): u64 {
+    public fun price_for_domain_v1(domain_length: u64, registration_secs: u64): u64 {
         assert!(domain_length >= 2, error::out_of_range(EDOMAIN_TOO_SHORT));
         let length_to_charge_for = math64::min(domain_length, 6);
+        let registration_years = (registration_secs / SECONDS_PER_YEAR as u8);
         scale_price_for_years(config::domain_price_for_length(length_to_charge_for), registration_years)
     }
 
@@ -57,28 +59,28 @@ module aptos_names_v2::price_model {
         config::set_domain_price_for_length(myself, (15 * config::octas()), 5);
         config::set_domain_price_for_length(myself, (5 * config::octas()), 6);
 
-        let price = price_for_domain_v1(2, 1) / config::octas();
+        let price = price_for_domain_v1(2, SECONDS_PER_YEAR) / config::octas();
         assert!(price == 100, price);
 
-        let price = price_for_domain_v1(4, 1) / config::octas();
+        let price = price_for_domain_v1(4, SECONDS_PER_YEAR) / config::octas();
         assert!(price == 30, price);
 
-        let price = price_for_domain_v1(2, 3) / config::octas();
+        let price = price_for_domain_v1(2, 3 * SECONDS_PER_YEAR) / config::octas();
         assert!(price == 335, price);
 
-        let price = price_for_domain_v1(5, 1) / config::octas();
+        let price = price_for_domain_v1(5, SECONDS_PER_YEAR) / config::octas();
         assert!(price == 15, price);
 
-        let price = price_for_domain_v1(5, 8) / config::octas();
+        let price = price_for_domain_v1(5, 8 * SECONDS_PER_YEAR) / config::octas();
         assert!(price == 204, price);
 
-        let price = price_for_domain_v1(10, 1) / config::octas();
+        let price = price_for_domain_v1(10, SECONDS_PER_YEAR) / config::octas();
         assert!(price == 5, price);
 
-        let price = price_for_domain_v1(15, 1) / config::octas();
+        let price = price_for_domain_v1(15, SECONDS_PER_YEAR) / config::octas();
         assert!(price == 5, price);
 
-        let price = price_for_domain_v1(15, 10) / config::octas();
+        let price = price_for_domain_v1(15, 10 * SECONDS_PER_YEAR) / config::octas();
         assert!(price == 102, price);
     }
 

--- a/core_v2/sources/subdomain_e2e_tests.move
+++ b/core_v2/sources/subdomain_e2e_tests.move
@@ -156,6 +156,15 @@ module aptos_names_v2::subdomain_e2e_tests {
     }
 
     #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
+    #[expected_failure(abort_code = 65561, location = aptos_names_v2::domains)]
+    fun test_register_domain_duration_not_whole_years(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
+        let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
+        let user = vector::borrow(&users, 0);
+        // Register the domain
+        test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs()+5, test_helper::fq_domain_name(), 1, vector::empty<u8>());
+    }
+
+    #[test(myself = @aptos_names_v2, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun names_are_registerable_after_expiry_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
         let users = test_helper::e2e_test_setup(myself, user, &aptos, rando, &foundation);
         let user = vector::borrow(&users, 0);

--- a/core_v2/sources/test_helper.move
+++ b/core_v2/sources/test_helper.move
@@ -74,12 +74,11 @@ module aptos_names_v2::test_helper {
         let set_name_address_event_v1_event_count_before = domains::get_set_name_address_event_v1_count();
         let set_reverse_lookup_event_v1_event_count_before = domains::get_set_reverse_lookup_event_v1_count();
 
-        let years = (time_helper::seconds_to_years(registration_duration_secs) as u8);
         if (option::is_none(&subdomain_name)) {
             if (vector::length(&signature)== 0) {
-                domains::register_domain(user, domain_name, years);
+                domains::register_domain(user, domain_name, registration_duration_secs);
             } else {
-                domains::register_domain_with_signature(user, domain_name, years, signature);
+                domains::register_domain_with_signature(user, domain_name, registration_duration_secs, signature);
             }
         } else {
             domains::register_subdomain(user, *option::borrow(&subdomain_name), domain_name, registration_duration_secs);
@@ -108,7 +107,7 @@ module aptos_names_v2::test_helper {
             // If it's a subdomain, we only charge a nomincal fee
             expected_user_balance_after = user_balance_before - price_model::price_for_subdomain_v1(registration_duration_secs);
         } else {
-            let domain_price = price_model::price_for_domain_v1(string::length(&domain_name), years);
+            let domain_price = price_model::price_for_domain_v1(string::length(&domain_name), registration_duration_secs);
             assert!(domain_price / config::octas() == 40, domain_price / config::octas());
             expected_user_balance_after = user_balance_before - domain_price;
         };


### PR DESCRIPTION
in this PR
1. use `set_subdomain_expiration` instead of renew to give domain owner more flexibility
2. remove num_years and use registration_duration_secs instead for the params 