### PR TITLE
[ans] set subdomain renew policy

### DIFF
--- a/core_v2/sources/domains.move
+++ b/core_v2/sources/domains.move
@@ -31,6 +31,10 @@ module aptos_names_v2::domains {
     const AUTO_RENEWAL_EXPIRATION_CUTOFF_SEC: u64 = 1709855999;
     const SECONDS_PER_YEAR: u64 = 60 * 60 * 24 * 365;
 
+    /// enums for subdomain expiration policy
+    const SUBDOMAIN_POLICY_LOOKUP_DOMAIN_EXPIRATION: u8 = 0;
+    const SUBDOMAIN_POLICY_MANUAL_SET_EXPIRATION: u8 = 1;
+
     /// The Naming Service contract is not enabled
     const ENOT_ENABLED: u64 = 1;
     /// The caller is not authorized to perform this operation
@@ -77,6 +81,8 @@ module aptos_names_v2::domains {
     const ESUBDOMAIN_EXPIRATION_PASS_DOMAIN_EXPIRATION: u64 = 24;
     /// The duration must be whole years
     const EDURATION_MUST_BE_WHOLE_YEARS: u64 = 25;
+    /// The subdomain expiration policy is included in the enum SUBDOMAIN_POLICY_*
+    const ESUBDOMAIN_EXPIRATION_POLICY_INVALID: u64 = 26;
 
     /// Tokens require a signer to create, so this is the signer for the collection
     struct CollectionCapabilityV2 has key, drop {
@@ -92,7 +98,7 @@ module aptos_names_v2::domains {
 
     struct SubdomainExt has store {
         subdomain_name: String,
-        use_domain_expiration_sec: bool,
+        subdomain_expiration_policy: u8,
     }
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
@@ -341,7 +347,7 @@ module aptos_names_v2::domains {
                 subdomain_name: option::extract(&mut subdomain_name),
                 // TODO: use_domain_expiration_sec should be passed in as a param
                 // Now by default subdomain follow domain's expiration
-                use_domain_expiration_sec: true,
+                subdomain_expiration_policy: SUBDOMAIN_POLICY_LOOKUP_DOMAIN_EXPIRATION,
             });
         }
         // creating domain
@@ -679,7 +685,7 @@ module aptos_names_v2::domains {
         let record = get_record_mut(domain_name, option::some(subdomain_name));
         assert!(option::is_some(&record.subdomain_ext), error::invalid_state(ENOT_A_SUBDOMAIN));
             let subdomain_ext = option::borrow(&record.subdomain_ext);
-            if (subdomain_ext.use_domain_expiration_sec) {
+            if (subdomain_ext.subdomain_expiration_policy == SUBDOMAIN_POLICY_LOOKUP_DOMAIN_EXPIRATION) {
                 assert!(false, error::invalid_state(ESUBDOMAIN_IS_AUTO_RENEW));
             };
 
@@ -691,9 +697,10 @@ module aptos_names_v2::domains {
         sign: &signer,
         domain_name: String,
         subdomain_name: String,
-        use_domain_expiration_sec: bool,
+        subdomain_expiration_policy: u8,
     ) acquires CollectionCapabilityV2, NameRecordV2 {
         validate_subdomain_to_renew(sign, subdomain_name, domain_name);
+        validate_subdomain_expiration_policy(subdomain_expiration_policy);
         // if manually set the expiration date
         let record = get_record_mut(domain_name, option::some(subdomain_name));
         // check the auto-renew flag
@@ -701,20 +708,30 @@ module aptos_names_v2::domains {
             assert!(false, error::invalid_state(ENOT_A_SUBDOMAIN));
         };
         let subdomain_ext = option::borrow_mut(&mut record.subdomain_ext);
-        subdomain_ext.use_domain_expiration_sec = use_domain_expiration_sec;
+        subdomain_ext.subdomain_expiration_policy = subdomain_expiration_policy;
     }
 
     public fun get_subdomain_renewal_policy(
         domain_name: String,
         subdomain_name: String,
-    ): bool acquires CollectionCapabilityV2, NameRecordV2 {
+    ): u8 acquires CollectionCapabilityV2, NameRecordV2 {
         let record = get_record_mut(domain_name, option::some(subdomain_name));
         // check the auto-renew flag
         if (!option::is_some(&record.subdomain_ext)) {
             assert!(false, error::invalid_state(ESUBDOMAIN_NOT_EXIST));
         };
         let subdomain_ext = option::borrow_mut(&mut record.subdomain_ext);
-        subdomain_ext.use_domain_expiration_sec
+        subdomain_ext.subdomain_expiration_policy
+    }
+
+    fun validate_subdomain_expiration_policy(
+        use_domain_expiration_sec: u8,
+    ) {
+        assert!(
+            use_domain_expiration_sec == SUBDOMAIN_POLICY_LOOKUP_DOMAIN_EXPIRATION
+                || use_domain_expiration_sec == SUBDOMAIN_POLICY_MANUAL_SET_EXPIRATION,
+            error::invalid_argument(ESUBDOMAIN_EXPIRATION_POLICY_INVALID)
+        );
     }
 
     fun validate_subdomain_to_renew(
@@ -760,7 +777,7 @@ module aptos_names_v2::domains {
             // check the auto-renew flag
             if (option::is_some(&record.subdomain_ext)) {
                 let subdomain_ext = option::borrow(&record.subdomain_ext);
-                if (subdomain_ext.use_domain_expiration_sec) {
+                if (subdomain_ext.subdomain_expiration_policy == SUBDOMAIN_POLICY_LOOKUP_DOMAIN_EXPIRATION) {
                     // refer to the expiration date of the domain
                     let domain_record = get_record(domain_name, option::none());
                     return time_is_expired(domain_record.expiration_time_sec)

--- a/core_v2/sources/domains.move
+++ b/core_v2/sources/domains.move
@@ -32,8 +32,8 @@ module aptos_names_v2::domains {
     const SECONDS_PER_YEAR: u64 = 60 * 60 * 24 * 365;
 
     /// enums for subdomain expiration policy. update validate_subdomain_expiration_policy() when adding more
-    const SUBDOMAIN_POLICY_LOOKUP_DOMAIN_EXPIRATION: u8 = 0;
-    const SUBDOMAIN_POLICY_MANUAL_SET_EXPIRATION: u8 = 1;
+    const SUBDOMAIN_POLICY_MANUAL_SET_EXPIRATION: u8 = 0;
+    const SUBDOMAIN_POLICY_LOOKUP_DOMAIN_EXPIRATION: u8 = 1;
     // const SUBDOMAIN_POLICY_NEXT_ENUM = 2
 
     /// The Naming Service contract is not enabled

--- a/core_v2/sources/domains.move
+++ b/core_v2/sources/domains.move
@@ -31,9 +31,10 @@ module aptos_names_v2::domains {
     const AUTO_RENEWAL_EXPIRATION_CUTOFF_SEC: u64 = 1709855999;
     const SECONDS_PER_YEAR: u64 = 60 * 60 * 24 * 365;
 
-    /// enums for subdomain expiration policy
+    /// enums for subdomain expiration policy. update validate_subdomain_expiration_policy() when adding more
     const SUBDOMAIN_POLICY_LOOKUP_DOMAIN_EXPIRATION: u8 = 0;
     const SUBDOMAIN_POLICY_MANUAL_SET_EXPIRATION: u8 = 1;
+    // const SUBDOMAIN_POLICY_NEXT_ENUM = 2
 
     /// The Naming Service contract is not enabled
     const ENOT_ENABLED: u64 = 1;
@@ -169,7 +170,7 @@ module aptos_names_v2::domains {
     struct RenewNameEventV1 has drop, store {
         domain_name: String,
         subdomain_name: Option<String>,
-        registration_fee_octas: u64,
+        renewal_fee_octas: u64,
         expiration_time_secs: u64,
     }
 
@@ -625,7 +626,7 @@ module aptos_names_v2::domains {
             RenewNameEventV1 {
                 domain_name,
                 subdomain_name: option::none(),
-                registration_fee_octas: price,
+                renewal_fee_octas: price,
                 expiration_time_secs: record.expiration_time_sec,
             },
         );
@@ -725,11 +726,13 @@ module aptos_names_v2::domains {
     }
 
     fun validate_subdomain_expiration_policy(
-        use_domain_expiration_sec: u8,
+        subdomain_expiration_policy: u8,
     ) {
+        // revise the function when adding more policies
+        // SUBDOMAIN_POLICY_NEXT_ENUM = 2
         assert!(
-            use_domain_expiration_sec == SUBDOMAIN_POLICY_LOOKUP_DOMAIN_EXPIRATION
-                || use_domain_expiration_sec == SUBDOMAIN_POLICY_MANUAL_SET_EXPIRATION,
+            subdomain_expiration_policy == SUBDOMAIN_POLICY_LOOKUP_DOMAIN_EXPIRATION
+                || subdomain_expiration_policy == SUBDOMAIN_POLICY_MANUAL_SET_EXPIRATION,
             error::invalid_argument(ESUBDOMAIN_EXPIRATION_POLICY_INVALID)
         );
     }

--- a/core_v2/sources/subdomain_e2e_tests.move
+++ b/core_v2/sources/subdomain_e2e_tests.move
@@ -130,7 +130,7 @@ module aptos_names_v2::subdomain_e2e_tests {
         // Register a subdomain!
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), timestamp::now_seconds() + test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
         // The subdomain auto-renewal policy is true by default
-        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()) == 0, 2);
+        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()) == 1, 2);
 
         // Renew the domain (and the subdomain should be auto renewed)
         let (original_expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::some(test_helper::subdomain_name()), test_helper::domain_name());
@@ -167,10 +167,10 @@ module aptos_names_v2::subdomain_e2e_tests {
 
         // Register a subdomain!
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
-        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()) == 0, 2);
+        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()) == 1, 2);
         // test set the policy to auto-renewal
-        domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), 1);
-        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()) == 1, 3);
+        domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), 0);
+        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()) == 0, 3);
 
         // test set the policy to something not exist
         domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), 100);
@@ -199,8 +199,8 @@ module aptos_names_v2::subdomain_e2e_tests {
 
         // Register a subdomain!
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
-        domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), 1);
-        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()) == 1, 2);
+        domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), 0);
+        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()) == 0, 2);
 
         // Set the time past the domain's expiration time
         let (expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::some(test_helper::subdomain_name()), test_helper::domain_name());
@@ -238,7 +238,7 @@ module aptos_names_v2::subdomain_e2e_tests {
         // Register a subdomain!
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
         // Set the auto-renewal flag as false
-        domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), 1);
+        domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), 0);
 
         domains::set_subdomain_expiration_as_domain_owner(user, test_helper::domain_name(), test_helper::subdomain_name(), timestamp::now_seconds() + 10);
         let (expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::some(test_helper::subdomain_name()), test_helper::domain_name());
@@ -321,7 +321,7 @@ module aptos_names_v2::subdomain_e2e_tests {
         // Register a subdomain!
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), timestamp::now_seconds() + test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
         // Set the subdomain auto-renewal policy to false
-        domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), 1);
+        domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), 0);
 
         // Set the time past the domain's expiration time
         let (expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::some(test_helper::subdomain_name()), test_helper::domain_name());

--- a/core_v2/sources/subdomain_e2e_tests.move
+++ b/core_v2/sources/subdomain_e2e_tests.move
@@ -167,9 +167,10 @@ module aptos_names_v2::subdomain_e2e_tests {
 
         // Register a subdomain!
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
+        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()) == 0, 2);
         // test set the policy to auto-renewal
         domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), 1);
-        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()) == 1, 2);
+        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()) == 1, 3);
 
         // test set the policy to something not exist
         domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), 100);


### PR DESCRIPTION
1. use enum instead of boolean for subdomain renewal policy
2. add the validation function to check if the renewal policy is correct
3. change the test names with prefix `test_`