### PR TITLE
Migrate primary name from v1 to v2

### DIFF
--- a/core_v2/sources/domain_e2e_tests.move
+++ b/core_v2/sources/domain_e2e_tests.move
@@ -898,6 +898,16 @@ module aptos_names_v2::domain_e2e_tests {
             assert!(time_helper::seconds_to_years(expiration_time_sec - timestamp::now_seconds()) == 2, 3);
             assert!(option::is_some(&target_addr), 4);
             assert!(*option::borrow(&target_addr) == user_addr, 5);
+
+            // Primary name should be migrated to v2
+            let maybe_reverse_record_addr = aptos_names_v2::domains::get_reverse_lookup(user_addr);
+            assert!(option::is_some(&maybe_reverse_record_addr), 6);
+            assert!(
+                aptos_names_v2::domains::token_addr(test_helper::domain_name(), option::none()) == option::extract(
+                    &mut maybe_reverse_record_addr
+                ),
+                7,
+            );
         }
     }
 
@@ -987,6 +997,16 @@ module aptos_names_v2::domain_e2e_tests {
             assert!(time_helper::seconds_to_years(expiration_time_sec - timestamp::now_seconds()) == 1, 3);
             assert!(option::is_some(&target_addr), 4);
             assert!(*option::borrow(&target_addr) == user_addr, 5);
+
+            // Primary name should be migrated to v2
+            let maybe_reverse_record_addr = aptos_names_v2::domains::get_reverse_lookup(user_addr);
+            assert!(option::is_some(&maybe_reverse_record_addr), 6);
+            assert!(
+                aptos_names_v2::domains::token_addr(test_helper::domain_name(), option::none()) == option::extract(
+                    &mut maybe_reverse_record_addr
+                ),
+                7,
+            );
         }
     }
 }

--- a/core_v2/sources/domains.move
+++ b/core_v2/sources/domains.move
@@ -1006,7 +1006,7 @@ module aptos_names_v2::domains {
         user: &signer,
         domain_name: String,
     ) acquires CollectionCapabilityV2, NameRecordV2, RegisterNameEventsV1, ReverseRecord, SetNameAddressEventsV1, SetReverseLookupEventsV1 {
-        let (expiration_time_sec, target_addr) = migrate_helper::burn_token_v1(
+        let (expiration_time_sec, target_addr, is_primary_name) = migrate_helper::burn_token_v1(
             user,
             &get_burn_signer(),
             domain_name,
@@ -1030,9 +1030,11 @@ module aptos_names_v2::domains {
         );
         // TODO: `register_name_internal` should accept a `target_addr`
         if (option::is_some(&target_addr)) {
-            set_name_address_internal(option::none(), domain_name, *option::borrow(&target_addr));
+            set_name_address(user, option::none(), domain_name, *option::borrow(&target_addr));
+        };
+        if (is_primary_name) {
+            set_reverse_lookup(user, option::none(), domain_name)
         }
-        // TODO: If the name was a primary name in v1 we should make it a primary name in v2
     }
 
     fun set_reverse_lookup_internal(


### PR DESCRIPTION
Note: `register_name_internal` will automatically set the primary name if a user does not have one in both `v1` and `v2`