### PR TITLE
[ans] default expiration policy as manual renew

### DIFF
--- a/core_v2/sources/domains.move
+++ b/core_v2/sources/domains.move
@@ -346,9 +346,7 @@ module aptos_names_v2::domains {
         if (is_subdomain(subdomain_name)) {
             subdomain_ext = option::some(SubdomainExt {
                 subdomain_name: option::extract(&mut subdomain_name),
-                // TODO: use_domain_expiration_sec should be passed in as a param
-                // Now by default subdomain follow domain's expiration
-                subdomain_expiration_policy: SUBDOMAIN_POLICY_LOOKUP_DOMAIN_EXPIRATION,
+                subdomain_expiration_policy: SUBDOMAIN_POLICY_MANUAL_SET_EXPIRATION,
             });
         }
         // creating domain

--- a/core_v2/sources/subdomain_e2e_tests.move
+++ b/core_v2/sources/subdomain_e2e_tests.move
@@ -129,8 +129,9 @@ module aptos_names_v2::subdomain_e2e_tests {
 
         // Register a subdomain!
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), timestamp::now_seconds() + test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
-        // The subdomain auto-renewal policy is true by default
-        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()) == 1, 2);
+        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()) == 0, 2);
+        // The subdomain auto-renewal policy is set to auto_renew
+        domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), 1);
 
         // Renew the domain (and the subdomain should be auto renewed)
         let (original_expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::some(test_helper::subdomain_name()), test_helper::domain_name());
@@ -167,10 +168,10 @@ module aptos_names_v2::subdomain_e2e_tests {
 
         // Register a subdomain!
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
-        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()) == 1, 2);
+        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()) == 0, 2);
         // test set the policy to auto-renewal
-        domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), 0);
-        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()) == 0, 3);
+        domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), 1);
+        assert!(domains::get_subdomain_renewal_policy(test_helper::domain_name(), test_helper::subdomain_name()) == 1, 3);
 
         // test set the policy to something not exist
         domains::set_subdomain_renewal_policy(user, test_helper::domain_name(), test_helper::subdomain_name(), 100);


### PR DESCRIPTION
set the default subdomain expiration policy as manual renewal (match the former behavior)