### PR TITLE
Update subdomain expiration migration logic

### DIFF
--- a/router/sources/migration_tests.move
+++ b/router/sources/migration_tests.move
@@ -215,8 +215,14 @@ module router::migration_tests {
         router::migrate_name(user, domain_name, subdomain_name_opt);
         assert!(router::is_name_owner(user_addr, domain_name, subdomain_name_opt), 7);
         assert!(*option::borrow(&router::get_target_addr(domain_name, subdomain_name_opt)) == user_addr, 8);
-        // Auto-renewal will not happen for subdomain
-        assert!(router::get_expiration(domain_name, subdomain_name_opt) == now + SECONDS_PER_YEAR, 9);
+        // Auto-renewal will not happen for subdomain. Instead, it will be the same as the parent domain
+        assert!(
+            router::get_expiration(domain_name, subdomain_name_opt) == router::get_expiration(
+                domain_name,
+                option::none()
+            ),
+            9
+        );
         {
             let (primary_subdomain_name, primary_domain_name) = router::get_primary_name(user_addr);
             assert!(*option::borrow(&primary_domain_name) == domain_name, 10);


### PR DESCRIPTION
Give migrated subdomains the same expiration as their domain. This was a product decision because, for example, if a domain expires in 5 days and its subdomain expires in 5 days:

1. domain migrates and autorenews to get an extra year. New expiration: 1 year, 5 days
2. subdomain migrates. We would prefer to give it new expiration of 1 year, 5 days as well so that it doesn't expire right away.