### PR TITLE
Update reverse lookup events to emit prev_*

### DIFF
--- a/core_v2/sources/domains.move
+++ b/core_v2/sources/domains.move
@@ -129,6 +129,7 @@ module aptos_names_v2::domains {
         /// The address this reverse lookup belongs to
         account_addr: address,
 
+        /// Indexer needs knowledge of previous state
         prev_domain_name: Option<String>,
         prev_subdomain_name: Option<String>,
         prev_expiration_time_secs: Option<u64>,


### PR DESCRIPTION
Motivation for this PR is to simplify indexing on primary name changes

1. Left TODO because noticed that we might not be accounting for dynamic subdomain expirations
2. Updated RenewNameEvent to emit `target_addr` and `is_primary_name`
3. Updated SetReverseLookupEvent to emit differently. Specifically, `account_addr` should always be the same for the same user, and we now track the delta from prev => curr state.