### PR TITLE
[ans] add clear target addr func to router

### DIFF
--- a/core/sources/domains.move
+++ b/core/sources/domains.move
@@ -621,7 +621,7 @@ module aptos_names::domains {
 
     /// This is a shared entry point for clearing the address of a domain or subdomain
     /// It enforces owner permissions
-    fun clear_name_address(
+    public fun clear_name_address(
         sign: &signer,
         subdomain_name: Option<String>,
         domain_name: String

--- a/core_v2/sources/domain_e2e_tests.move
+++ b/core_v2/sources/domain_e2e_tests.move
@@ -209,7 +209,7 @@ module aptos_names_v2::domain_e2e_tests {
         foundation = @0xf01d
     )]
     #[expected_failure(abort_code = 327689, location = aptos_names_v2::domains)]
-    fun dont_allow_rando_to_set_domain_address_e2e_test(
+    fun test_non_owner_can_not_set_target_address(
         router_signer: &signer,
         aptos_names_v2: &signer,
         user: signer,
@@ -236,7 +236,7 @@ module aptos_names_v2::domain_e2e_tests {
         foundation = @0xf01d
     )]
     #[expected_failure(abort_code = 327682, location = aptos_names_v2::domains)]
-    fun dont_allow_rando_to_clear_domain_address_e2e_test(
+    fun test_non_owner_can_not_clear_target_address(
         router_signer: &signer,
         aptos_names_v2: &signer,
         user: signer,
@@ -264,7 +264,7 @@ module aptos_names_v2::domain_e2e_tests {
         rando = @0x266f,
         foundation = @0xf01d
     )]
-    fun owner_can_clear_domain_address_e2e_test(
+    fun test_owner_can_clear_domain_address(
         router_signer: &signer,
         aptos_names_v2: &signer,
         user: signer,
@@ -282,6 +282,34 @@ module aptos_names_v2::domain_e2e_tests {
 
         // Ensure we can clear as owner
         test_helper::clear_target_address(user, option::none(), test_helper::domain_name());
+    }
+
+    #[test(
+        router_signer = @router_signer,
+        aptos_names_v2 = @aptos_names_v2,
+        user = @0x077,
+        aptos = @0x1,
+        rando = @0x266f,
+        foundation = @0xf01d
+    )]
+    fun test_target_addr_owner_can_clear_target_address(
+        router_signer: &signer,
+        aptos_names_v2: &signer,
+        user: signer,
+        aptos: signer,
+        rando: signer,
+        foundation: signer,
+    ) {
+        let users = test_helper::e2e_test_setup(aptos_names_v2, user, &aptos, rando, &foundation);
+        let user = vector::borrow(&users, 0);
+        let rando = vector::borrow(&users, 1);
+
+        // Register the domain, and set its address
+        test_helper::register_name(router_signer, user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1);
+        test_helper::set_target_address(user, option::none(), test_helper::domain_name(), signer::address_of(rando));
+
+        // Ensure we can clear as owner
+        test_helper::clear_target_address(rando, option::none(), test_helper::domain_name());
     }
 
     #[test(

--- a/core_v2/sources/domains.move
+++ b/core_v2/sources/domains.move
@@ -978,24 +978,9 @@ module aptos_names_v2::domains {
         );
     }
 
-    public entry fun clear_domain_address(
-        sign: &signer,
-        domain_name: String
-    ) acquires CollectionCapability, NameRecord, ReverseRecord, SetTargetAddressEvents, SetReverseLookupEvents {
-        clear_target_address(sign, option::none(), domain_name);
-    }
-
-    public entry fun clear_subdomain_address(
-        sign: &signer,
-        subdomain_name: String,
-        domain_name: String
-    ) acquires CollectionCapability, NameRecord, ReverseRecord, SetTargetAddressEvents, SetReverseLookupEvents {
-        clear_target_address(sign, option::some(subdomain_name), domain_name);
-    }
-
     /// This is a shared entry point for clearing the address of a domain or subdomain
     /// It enforces owner permissions
-    fun clear_target_address(
+    public fun clear_target_address(
         sign: &signer,
         subdomain_name: Option<String>,
         domain_name: String

--- a/core_v2/sources/test_helper.move
+++ b/core_v2/sources/test_helper.move
@@ -336,12 +336,7 @@ module aptos_names_v2::test_helper {
         let set_reverse_lookup_event_event_count_before = domains::get_set_reverse_lookup_event_count();
         let maybe_reverse_lookup_before = domains::get_reverse_lookup(user_addr);
 
-        // And also can clear if is registered address, but not owner
-        if (option::is_none(&subdomain_name)) {
-            domains::clear_domain_address(user, domain_name);
-        } else {
-            domains::clear_subdomain_address(user, *option::borrow(&subdomain_name), domain_name);
-        };
+        domains::clear_target_address(user, subdomain_name, domain_name);
         let (_expiration_time_sec, target_address) = domains::get_name_record_props_for_name(
             subdomain_name,
             domain_name

--- a/router/sources/router.move
+++ b/router/sources/router.move
@@ -329,7 +329,7 @@ module router::router {
             let now = timestamp::now_seconds();
             let new_expiration_time_sec = if (option::is_some(&subdomain_name)) {
                 // Subdomains inherit the expiration of their domain
-                let (domain_expiration_time_sec, _domain_target_addr) = aptos_names_v2::domains::get_name_record_v1_props_for_name(
+                let (domain_expiration_time_sec, _domain_target_addr) = aptos_names_v2::domains::get_name_record_props_for_name(
                     option::none(),
                     domain_name,
                 );
@@ -493,6 +493,29 @@ module router::router {
                 subdomain_name,
                 domain_name,
                 target_addr,
+            )
+        } else {
+            abort error::not_implemented(ENOT_IMPLEMENTED_IN_MODE)
+        }
+    }
+
+    public entry fun clear_target_addr(
+        user: &signer,
+        domain_name: String,
+        subdomain_name: Option<String>,
+    ) acquires RouterConfig {
+        let mode = get_mode();
+        if (mode == MODE_V1) {
+            aptos_names::domains::clear_name_address(
+                user,
+                subdomain_name,
+                domain_name,
+            )
+        } else if (mode == MODE_V1_AND_V2) {
+            aptos_names_v2::domains::clear_target_address(
+                user,
+                subdomain_name,
+                domain_name,
             )
         } else {
             abort error::not_implemented(ENOT_IMPLEMENTED_IN_MODE)


### PR DESCRIPTION
- adding clear target addr func to router
- delete `clear_domain_address` and `clear_subdomain_address` because we no longer avoid optional input for `public entry fun` 