### PR TITLE
[ans] remove unused domain/subdomain specific functions

### DIFF
--- a/core_v2/sources/domain_e2e_tests.move
+++ b/core_v2/sources/domain_e2e_tests.move
@@ -344,7 +344,7 @@ module aptos_names_v2::domain_e2e_tests {
             1,
         );
 
-        domains::force_set_domain_address(aptos_names_v2, test_helper::domain_name(), rando_addr);
+        domains::force_set_target_address(aptos_names_v2, test_helper::domain_name(), option::none(), rando_addr);
         let (_expiration_time_sec, target_address) = domains::get_name_record_props_for_name(
             option::none(),
             test_helper::domain_name()
@@ -380,7 +380,7 @@ module aptos_names_v2::domain_e2e_tests {
         test_helper::register_name(router_signer, user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1);
 
         // Rando is not allowed to do this
-        domains::force_set_domain_address(rando, test_helper::domain_name(), rando_addr);
+        domains::force_set_target_address(rando, test_helper::domain_name(), option::none(), rando_addr);
     }
 
     #[test(
@@ -654,7 +654,7 @@ module aptos_names_v2::domain_e2e_tests {
 
         // Verify primary name for |user| hasn't changed
         assert!(option::is_some(&domains::get_reverse_lookup(user_addr)), 1);
-        assert!(*option::borrow(&domains::name_resolved_address(option::none(), test_helper::domain_name())) == user_addr, 1);
+        assert!(*option::borrow(&domains::get_name_resolved_address(option::none(), test_helper::domain_name())) == user_addr, 1);
 
         // |rando| sets his primary name
         let domain_name_str = string::utf8(b"test");
@@ -662,7 +662,7 @@ module aptos_names_v2::domain_e2e_tests {
 
         // |user|'s primary name should be none.
         assert!(option::is_none(&domains::get_reverse_lookup(user_addr)), 1);
-        assert!(*option::borrow(&domains::name_resolved_address(option::none(), test_helper::domain_name())) == rando_addr, 1);
+        assert!(*option::borrow(&domains::get_name_resolved_address(option::none(), test_helper::domain_name())) == rando_addr, 1);
     }
 
     #[test(
@@ -698,7 +698,7 @@ module aptos_names_v2::domain_e2e_tests {
 
         // Verify primary name for |user| hasn't changed
         assert!(option::is_some(&domains::get_reverse_lookup(user_addr)), 1);
-        assert!(*option::borrow(&domains::name_resolved_address(option::none(), test_helper::domain_name())) == user_addr, 1);
+        assert!(*option::borrow(&domains::get_name_resolved_address(option::none(), test_helper::domain_name())) == user_addr, 1);
 
         // |rando| sets target address
         let domain_name_str = string::utf8(b"test");
@@ -706,7 +706,7 @@ module aptos_names_v2::domain_e2e_tests {
 
         // |user|'s primary name should be none.
         assert!(option::is_none(&domains::get_reverse_lookup(user_addr)), 1);
-        assert!(*option::borrow(&domains::name_resolved_address(option::none(), test_helper::domain_name())) == rando_addr, 1);
+        assert!(*option::borrow(&domains::get_name_resolved_address(option::none(), test_helper::domain_name())) == rando_addr, 1);
     }
 
     #[test(
@@ -780,7 +780,7 @@ module aptos_names_v2::domain_e2e_tests {
             assert!(is_owner, 1);
         };
 
-        let token_addr = domains::token_addr(test_helper::domain_name(), option::none());
+        let token_addr = domains::get_token_addr(test_helper::domain_name(), option::none());
         object::transfer_raw(user, token_addr, rando_addr);
 
         // rando is owner

--- a/core_v2/sources/query_helper.move
+++ b/core_v2/sources/query_helper.move
@@ -94,7 +94,7 @@ module aptos_names_v2::query_helper {
     public fun domain_name_resolved_address(
         domain_name: String
     ): Option<address> {
-        domains::name_resolved_address(option::none(), domain_name)
+        domains::get_name_resolved_address(option::none(), domain_name)
     }
 
     #[view]
@@ -104,6 +104,6 @@ module aptos_names_v2::query_helper {
         subdomain_name: String,
         domain_name: String
     ): Option<address> {
-        domains::name_resolved_address(option::some(subdomain_name), domain_name)
+        domains::get_name_resolved_address(option::some(subdomain_name), domain_name)
     }
 }

--- a/core_v2/sources/subdomain_e2e_tests.move
+++ b/core_v2/sources/subdomain_e2e_tests.move
@@ -654,7 +654,7 @@ module aptos_names_v2::subdomain_e2e_tests {
         test_helper::register_name(router_signer, user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1);
         test_helper::register_name(router_signer, user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1);
 
-        domains::force_set_subdomain_address(aptos_names_v2, test_helper::domain_name(), test_helper::subdomain_name(), rando_addr);
+        domains::force_set_target_address(aptos_names_v2, test_helper::domain_name(), option::some(test_helper::subdomain_name()), rando_addr);
         let (_expiration_time_sec, target_address) = domains::get_name_record_props_for_name(option::some(test_helper::subdomain_name()), test_helper::domain_name());
         test_utils::print_actual_expected(b"set_subdomain_address: ", target_address, option::some(rando_addr), false);
         assert!(target_address == option::some(rando_addr), 33);
@@ -689,7 +689,7 @@ module aptos_names_v2::subdomain_e2e_tests {
         test_helper::register_name(router_signer, user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1);
 
         // Rando is not allowed to do this
-        domains::force_set_subdomain_address(rando, test_helper::subdomain_name(), test_helper::domain_name(), rando_addr);
+        domains::force_set_target_address(rando, test_helper::domain_name(), option::some(test_helper::subdomain_name()), rando_addr);
     }
 
     #[test(

--- a/core_v2/sources/test_helper.move
+++ b/core_v2/sources/test_helper.move
@@ -83,12 +83,12 @@ module aptos_names_v2::test_helper {
 
         let user_balance_before = coin::balance<AptosCoin>(user_addr);
         let user_reverse_lookup_before = domains::get_reverse_lookup(user_addr);
-        let maybe_target_address = domains::name_resolved_address(subdomain_name, domain_name);
+        let maybe_target_address = domains::get_name_resolved_address(subdomain_name, domain_name);
         let was_primary_name_before = if (option::is_some(&maybe_target_address)) {
             let maybe_primary_name = domains::get_reverse_lookup(*option::borrow(&maybe_target_address));
             if (option::is_some(&maybe_primary_name)) {
                 // Even if target_addr has a primary name, it may not necessarily point to this `(domain_name, subdomain_name)`
-                *option::borrow(&maybe_primary_name) == domains::token_addr(domain_name, subdomain_name)
+                *option::borrow(&maybe_primary_name) == domains::get_token_addr(domain_name, subdomain_name)
             } else {
                 // No primary name, so definitely was not primary name before
                 false
@@ -218,7 +218,7 @@ module aptos_names_v2::test_helper {
             );
             if (option::is_some(&maybe_reverse_lookup_after)) {
                 let reverse_lookup_after = option::borrow(&maybe_reverse_lookup_after);
-                assert!(*reverse_lookup_after == domains::token_addr(domain_name, subdomain_name), 36);
+                assert!(*reverse_lookup_after == domains::get_token_addr(domain_name, subdomain_name), 36);
                 assert!(subdomain_name_lookup_result == subdomain_name, 136);
                 assert!(domain_name_lookup_result == option::some(domain_name), 137);
             } else {
@@ -346,7 +346,7 @@ module aptos_names_v2::test_helper {
 
         if (option::is_some(&maybe_reverse_lookup_before)) {
             let reverse_lookup_before = option::borrow(&maybe_reverse_lookup_before);
-            if (*reverse_lookup_before == domains::token_addr(domain_name, subdomain_name)) {
+            if (*reverse_lookup_before == domains::get_token_addr(domain_name, subdomain_name)) {
                 let reverse_lookup_after = domains::get_reverse_lookup(user_addr);
                 assert!(option::is_none(&reverse_lookup_after), 35);
 

--- a/router/sources/router.move
+++ b/router/sources/router.move
@@ -405,7 +405,7 @@ module router::router {
 
             // TODO: Probably good idea to clear entries in v1
         } else if (mode == MODE_V1_AND_V2) {
-            let token_addr = aptos_names_v2::domains::token_addr(domain_name, subdomain_name);
+            let token_addr = aptos_names_v2::domains::get_token_addr(domain_name, subdomain_name);
             object::transfer(
                 user,
                 object::address_to_object<aptos_names_v2::domains::NameRecord>(token_addr),
@@ -620,7 +620,7 @@ module router::router {
 
     /// Returns true if the name is tracked in v2
     inline fun exists_in_v2(domain_name: String, subdomain_name: Option<String>): bool {
-        object::is_object(aptos_names_v2::domains::token_addr(domain_name, subdomain_name))
+        object::is_object(aptos_names_v2::domains::get_token_addr(domain_name, subdomain_name))
     }
 
     inline fun get_v1_target_addr(


### PR DESCRIPTION
- remove the domain/subdomain specific entry function, because we no longer avoid optional inputs in `public entry fun`
- more rename functions