### PR TITLE
throw error when setting an unregistered name as primary name

### DIFF
--- a/core_v2/sources/domain_e2e_tests.move
+++ b/core_v2/sources/domain_e2e_tests.move
@@ -821,4 +821,39 @@ module aptos_names_v2::domain_e2e_tests {
             assert!(is_expired, 1);
         };
     }
+
+    #[test(
+        router_signer = @router_signer,
+        aptos_names_v2 = @aptos_names_v2,
+        user = @0x077,
+        aptos = @0x1,
+        rando = @0x266f,
+        foundation = @0xf01d
+    )]
+    #[expected_failure(abort_code = 393221, location = aptos_names_v2::domains)]
+    fun test_cannot_set_unregistered_name_as_primary_name(
+        router_signer: &signer,
+        aptos_names_v2: &signer,
+        user: signer,
+        aptos: signer,
+        rando: signer,
+        foundation: signer,
+    ) {
+        let users = test_helper::e2e_test_setup(aptos_names_v2, user, &aptos, rando, &foundation);
+        let user = vector::borrow(&users, 0);
+
+        // Register the domain
+        test_helper::register_name(
+            router_signer,
+            user,
+            option::none(),
+            test_helper::domain_name(),
+            test_helper::one_year_secs(),
+            test_helper::fq_domain_name(),
+            1
+        );
+
+        // Set a not exist domain as primary name, should trigger ENAME_NOT_EXIST error
+        aptos_names_v2::domains::set_reverse_lookup(user, option::none(), string::utf8(b"notexist"));
+    }
 }

--- a/core_v2/sources/domains.move
+++ b/core_v2/sources/domains.move
@@ -669,9 +669,7 @@ module aptos_names_v2::domains {
         domain_name: String
     ) acquires CollectionCapability, NameRecord, ReverseRecord, SetTargetAddressEvents, SetReverseLookupEvents {
         // Name must be registered before assigning reverse lookup
-        if (!is_name_registered(domain_name, subdomain_name)) {
-            return
-        };
+        assert!(is_name_registered(domain_name, subdomain_name), error::not_found(ENAME_NOT_EXIST));
         let token_addr = get_token_addr_inline(domain_name, subdomain_name);
         set_target_address(account, domain_name, subdomain_name, address_of(account));
         set_reverse_lookup_internal(account, token_addr);


### PR DESCRIPTION
current behavior is it will return and nothing happen (so fail silently) which is confusing to user