### PR TITLE
deprecate v1's is_owner_of_name to avoid confusion

### DIFF
--- a/core/sources/domain_e2e_tests.move
+++ b/core/sources/domain_e2e_tests.move
@@ -241,11 +241,13 @@ module aptos_names::domain_e2e_tests {
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
+        assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
 
         // Take the domain name for much longer than users are allowed to register it for
         domains::force_create_or_seize_name(myself, option::none(), test_helper::domain_name(), test_helper::two_hundred_year_secs());
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(myself), option::none(), test_helper::domain_name());
         assert!(is_owner, 2);
+        assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
 
         // Ensure the expiration_time_sec is set to the new far future value
         let (_, expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::none(), test_helper::domain_name());
@@ -266,6 +268,7 @@ module aptos_names::domain_e2e_tests {
             test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
             let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::none(), test_helper::domain_name());
             assert!(is_owner, 1);
+            assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
         };
 
         // Register another domain. This will **not** be the user's reverse lookup
@@ -274,11 +277,13 @@ module aptos_names::domain_e2e_tests {
         test_helper::register_name(user, option::none(), domain_name, test_helper::one_year_secs(), fq_domain_name, 1, vector::empty<u8>());
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::none(), domain_name);
         assert!(is_owner, 1);
+        assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
 
         // Take the domain name for much longer than users are allowed to register it for
         domains::force_create_or_seize_name(myself, option::none(), domain_name, test_helper::two_hundred_year_secs());
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(myself), option::none(), domain_name);
         assert!(is_owner, 2);
+        assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 2);
 
         // Ensure the expiration_time_sec is set to the new far future value
         let (_, expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::none(), domain_name);
@@ -299,6 +304,7 @@ module aptos_names::domain_e2e_tests {
         domains::force_create_or_seize_name(myself, option::none(), test_helper::domain_name(), test_helper::two_hundred_year_secs());
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(myself), option::none(), test_helper::domain_name());
         assert!(is_owner, 2);
+        assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 2);
 
         // Ensure the expiration_time_sec is set to the new far future value
         let (_, expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::none(), test_helper::domain_name());
@@ -392,6 +398,7 @@ module aptos_names::domain_e2e_tests {
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
+        assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
 
         // Take the domain name for much longer than users are allowed to register it for
         domains::force_create_or_seize_name(rando, option::none(), test_helper::domain_name(), test_helper::two_hundred_year_secs());
@@ -437,6 +444,7 @@ module aptos_names::domain_e2e_tests {
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
         let (is_owner, token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
+        assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
 
         // Transfer the domain to rando
         token::direct_transfer(user, rando, token_id, 1);
@@ -467,6 +475,7 @@ module aptos_names::domain_e2e_tests {
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
         let (is_owner, token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
+        assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
 
         // Transfer the domain to rando
         token::direct_transfer(user, rando, token_id, 1);
@@ -494,6 +503,7 @@ module aptos_names::domain_e2e_tests {
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
         let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
+        assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
 
         // Set the time past the domain's expiration time
         let (_, expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::none(), test_helper::domain_name());
@@ -544,6 +554,7 @@ module aptos_names::domain_e2e_tests {
         );
         let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
+        assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
 
         // Set the time right before the domain's expiration time + grace period
         let (_, expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::none(), test_helper::domain_name());
@@ -587,6 +598,7 @@ module aptos_names::domain_e2e_tests {
         );
         let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
+        assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
 
         // Set the time past the domain's expiration time + grace period
         let (_, expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::none(), test_helper::domain_name());

--- a/core/sources/domain_e2e_tests.move
+++ b/core/sources/domain_e2e_tests.move
@@ -239,12 +239,12 @@ module aptos_names::domain_e2e_tests {
 
         // Register the domain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
 
         // Take the domain name for much longer than users are allowed to register it for
         domains::force_create_or_seize_name(myself, option::none(), test_helper::domain_name(), test_helper::two_hundred_year_secs());
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(myself), option::none(), test_helper::domain_name());
+        let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(myself), option::none(), test_helper::domain_name());
         assert!(is_owner, 2);
 
         // Ensure the expiration_time_sec is set to the new far future value
@@ -264,7 +264,7 @@ module aptos_names::domain_e2e_tests {
         // Register the domain. This will be the user's reverse lookup
         {
             test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
-            let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+            let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::none(), test_helper::domain_name());
             assert!(is_owner, 1);
         };
 
@@ -272,12 +272,12 @@ module aptos_names::domain_e2e_tests {
         let domain_name = string::utf8(b"sets");
         let fq_domain_name = string::utf8(b"sets.apt");
         test_helper::register_name(user, option::none(), domain_name, test_helper::one_year_secs(), fq_domain_name, 1, vector::empty<u8>());
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), domain_name);
+        let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::none(), domain_name);
         assert!(is_owner, 1);
 
         // Take the domain name for much longer than users are allowed to register it for
         domains::force_create_or_seize_name(myself, option::none(), domain_name, test_helper::two_hundred_year_secs());
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(myself), option::none(), domain_name);
+        let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(myself), option::none(), domain_name);
         assert!(is_owner, 2);
 
         // Ensure the expiration_time_sec is set to the new far future value
@@ -297,7 +297,7 @@ module aptos_names::domain_e2e_tests {
 
         // Take the domain name for much longer than users are allowed to register it for
         domains::force_create_or_seize_name(myself, option::none(), test_helper::domain_name(), test_helper::two_hundred_year_secs());
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(myself), option::none(), test_helper::domain_name());
+        let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(myself), option::none(), test_helper::domain_name());
         assert!(is_owner, 2);
 
         // Ensure the expiration_time_sec is set to the new far future value
@@ -390,7 +390,7 @@ module aptos_names::domain_e2e_tests {
 
         // Register the domain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
 
         // Take the domain name for much longer than users are allowed to register it for
@@ -435,7 +435,7 @@ module aptos_names::domain_e2e_tests {
 
         // Register the domain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
-        let (is_owner, token_id) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
+        let (is_owner, token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
 
         // Transfer the domain to rando
@@ -465,7 +465,7 @@ module aptos_names::domain_e2e_tests {
 
         // Register the domain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
-        let (is_owner, token_id) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
+        let (is_owner, token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
 
         // Transfer the domain to rando
@@ -492,15 +492,17 @@ module aptos_names::domain_e2e_tests {
 
         // Register the domain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
-        let (is_owner, _token_id) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
+        let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
 
         // Set the time past the domain's expiration time
         let (_, expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::none(), test_helper::domain_name());
         timestamp::update_global_time_for_test_secs(expiration_time_sec + 5);
 
-        let (is_owner, _token_id) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
-        assert!(!is_owner, 1);
+        // Is owner, but name has expired
+        let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
+        assert!(is_owner, 1);
+        assert!(domains::name_is_expired(option::none(), test_helper::domain_name()), 2);
     }
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
@@ -540,16 +542,17 @@ module aptos_names::domain_e2e_tests {
             1,
             vector::empty<u8>()
         );
-        let (is_owner, _token_id) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
+        let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
 
         // Set the time right before the domain's expiration time + grace period
         let (_, expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::none(), test_helper::domain_name());
         timestamp::update_global_time_for_test_secs(expiration_time_sec + config::reregistration_grace_sec());
 
-        // Not owner anymore, name has expired
-        let (is_owner, _token_id) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
-        assert!(!is_owner, 1);
+        // Is owner, but name has expired
+        let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
+        assert!(is_owner, 1);
+        assert!(domains::name_is_expired(option::none(), test_helper::domain_name()), 2);
 
         // Register the domain again. Should fail because it's still in the grace period
         test_helper::register_name(
@@ -582,16 +585,17 @@ module aptos_names::domain_e2e_tests {
             1,
             vector::empty<u8>()
         );
-        let (is_owner, _token_id) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
+        let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
 
         // Set the time past the domain's expiration time + grace period
         let (_, expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::none(), test_helper::domain_name());
         timestamp::update_global_time_for_test_secs(expiration_time_sec + config::reregistration_grace_sec() + 1);
 
-        // Not owner anymore, name has expired
-        let (is_owner, _token_id) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
-        assert!(!is_owner, 1);
+        // Is owner but name has expired
+        let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
+        assert!(is_owner, 1);
+        assert!(domains::name_is_expired(option::none(), test_helper::domain_name()), 2);
 
         // Register the domain again. Works because it's past the grace period
         test_helper::register_name(

--- a/core/sources/domain_e2e_tests.move
+++ b/core/sources/domain_e2e_tests.move
@@ -457,7 +457,7 @@ module aptos_names::domain_e2e_tests {
 
         // Register the domain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
-        let (is_owner, token_id) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
+        let (is_owner, _) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         let (is_owner, token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);

--- a/core/sources/domain_e2e_tests.move
+++ b/core/sources/domain_e2e_tests.move
@@ -12,6 +12,7 @@ module aptos_names::domain_e2e_tests {
     use std::signer;
     use std::string;
     use std::vector;
+    use aptos_names::test_helper::domain_name;
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun happy_path_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
@@ -272,7 +273,7 @@ module aptos_names::domain_e2e_tests {
             test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
             let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
             assert!(is_owner, 1);
-            let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::none(), test_helper::domain_name());
+            let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::none(), domain_name());
             assert!(is_owner, 1);
             assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
         };
@@ -281,7 +282,7 @@ module aptos_names::domain_e2e_tests {
         let domain_name = string::utf8(b"sets");
         let fq_domain_name = string::utf8(b"sets.apt");
         test_helper::register_name(user, option::none(), domain_name, test_helper::one_year_secs(), fq_domain_name, 1, vector::empty<u8>());
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), domain_name);
         assert!(is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::none(), domain_name);
         assert!(is_owner, 1);
@@ -289,7 +290,7 @@ module aptos_names::domain_e2e_tests {
 
         // Take the domain name for much longer than users are allowed to register it for
         domains::force_create_or_seize_name(myself, option::none(), domain_name, test_helper::two_hundred_year_secs());
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), domain_name);
         assert!(is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(myself), option::none(), domain_name);
         assert!(is_owner, 2);
@@ -456,7 +457,7 @@ module aptos_names::domain_e2e_tests {
 
         // Register the domain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        let (is_owner, token_id) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         let (is_owner, token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
@@ -489,7 +490,7 @@ module aptos_names::domain_e2e_tests {
 
         // Register the domain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        let (is_owner, _) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         let (is_owner, token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
@@ -519,7 +520,7 @@ module aptos_names::domain_e2e_tests {
 
         // Register the domain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        let (is_owner, _token_id) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
@@ -530,7 +531,7 @@ module aptos_names::domain_e2e_tests {
         timestamp::update_global_time_for_test_secs(expiration_time_sec + 5);
 
         // Is owner, but name has expired
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        let (is_owner, _token_id) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
         assert!(!is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
@@ -574,7 +575,7 @@ module aptos_names::domain_e2e_tests {
             1,
             vector::empty<u8>()
         );
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        let (is_owner, _token_id) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
@@ -584,9 +585,10 @@ module aptos_names::domain_e2e_tests {
         let (_, expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::none(), test_helper::domain_name());
         timestamp::update_global_time_for_test_secs(expiration_time_sec + config::reregistration_grace_sec());
 
-        // Is owner, but name has expired
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        // Not owner anymore, name has expired
+        let (is_owner, _token_id) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
         assert!(!is_owner, 1);
+        // Is owner, but name has expired
         let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         assert!(domains::name_is_expired(option::none(), test_helper::domain_name()), 2);
@@ -622,7 +624,7 @@ module aptos_names::domain_e2e_tests {
             1,
             vector::empty<u8>()
         );
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        let (is_owner, _token_id) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
@@ -632,9 +634,10 @@ module aptos_names::domain_e2e_tests {
         let (_, expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::none(), test_helper::domain_name());
         timestamp::update_global_time_for_test_secs(expiration_time_sec + config::reregistration_grace_sec() + 1);
 
-        // Is owner but name has expired
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        // Not owner anymore, name has expired
+        let (is_owner, _token_id) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
         assert!(!is_owner, 1);
+        // Is owner but name has expired
         let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         assert!(domains::name_is_expired(option::none(), test_helper::domain_name()), 2);

--- a/core/sources/domain_e2e_tests.move
+++ b/core/sources/domain_e2e_tests.move
@@ -239,12 +239,16 @@ module aptos_names::domain_e2e_tests {
 
         // Register the domain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        assert!(is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
 
         // Take the domain name for much longer than users are allowed to register it for
         domains::force_create_or_seize_name(myself, option::none(), test_helper::domain_name(), test_helper::two_hundred_year_secs());
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(myself), option::none(), test_helper::domain_name());
+        assert!(is_owner, 2);
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(myself), option::none(), test_helper::domain_name());
         assert!(is_owner, 2);
         assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
@@ -266,6 +270,8 @@ module aptos_names::domain_e2e_tests {
         // Register the domain. This will be the user's reverse lookup
         {
             test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
+            let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+            assert!(is_owner, 1);
             let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::none(), test_helper::domain_name());
             assert!(is_owner, 1);
             assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
@@ -275,12 +281,16 @@ module aptos_names::domain_e2e_tests {
         let domain_name = string::utf8(b"sets");
         let fq_domain_name = string::utf8(b"sets.apt");
         test_helper::register_name(user, option::none(), domain_name, test_helper::one_year_secs(), fq_domain_name, 1, vector::empty<u8>());
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        assert!(is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::none(), domain_name);
         assert!(is_owner, 1);
         assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
 
         // Take the domain name for much longer than users are allowed to register it for
         domains::force_create_or_seize_name(myself, option::none(), domain_name, test_helper::two_hundred_year_secs());
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        assert!(is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(myself), option::none(), domain_name);
         assert!(is_owner, 2);
         assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 2);
@@ -302,6 +312,8 @@ module aptos_names::domain_e2e_tests {
 
         // Take the domain name for much longer than users are allowed to register it for
         domains::force_create_or_seize_name(myself, option::none(), test_helper::domain_name(), test_helper::two_hundred_year_secs());
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(myself), option::none(), test_helper::domain_name());
+        assert!(is_owner, 2);
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(myself), option::none(), test_helper::domain_name());
         assert!(is_owner, 2);
         assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 2);
@@ -396,6 +408,8 @@ module aptos_names::domain_e2e_tests {
 
         // Register the domain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        assert!(is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
@@ -442,6 +456,8 @@ module aptos_names::domain_e2e_tests {
 
         // Register the domain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        assert!(is_owner, 1);
         let (is_owner, token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
@@ -473,6 +489,8 @@ module aptos_names::domain_e2e_tests {
 
         // Register the domain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        assert!(is_owner, 1);
         let (is_owner, token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
@@ -501,6 +519,8 @@ module aptos_names::domain_e2e_tests {
 
         // Register the domain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        assert!(is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
@@ -510,6 +530,8 @@ module aptos_names::domain_e2e_tests {
         timestamp::update_global_time_for_test_secs(expiration_time_sec + 5);
 
         // Is owner, but name has expired
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        assert!(!is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         assert!(domains::name_is_expired(option::none(), test_helper::domain_name()), 2);
@@ -552,6 +574,8 @@ module aptos_names::domain_e2e_tests {
             1,
             vector::empty<u8>()
         );
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        assert!(is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
@@ -561,6 +585,8 @@ module aptos_names::domain_e2e_tests {
         timestamp::update_global_time_for_test_secs(expiration_time_sec + config::reregistration_grace_sec());
 
         // Is owner, but name has expired
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        assert!(!is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         assert!(domains::name_is_expired(option::none(), test_helper::domain_name()), 2);
@@ -596,6 +622,8 @@ module aptos_names::domain_e2e_tests {
             1,
             vector::empty<u8>()
         );
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        assert!(is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
@@ -605,6 +633,8 @@ module aptos_names::domain_e2e_tests {
         timestamp::update_global_time_for_test_secs(expiration_time_sec + config::reregistration_grace_sec() + 1);
 
         // Is owner but name has expired
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
+        assert!(!is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());
         assert!(is_owner, 1);
         assert!(domains::name_is_expired(option::none(), test_helper::domain_name()), 2);

--- a/core/sources/domain_e2e_tests.move
+++ b/core/sources/domain_e2e_tests.move
@@ -290,7 +290,7 @@ module aptos_names::domain_e2e_tests {
 
         // Take the domain name for much longer than users are allowed to register it for
         domains::force_create_or_seize_name(myself, option::none(), domain_name, test_helper::two_hundred_year_secs());
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), domain_name);
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(myself), option::none(), domain_name);
         assert!(is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(myself), option::none(), domain_name);
         assert!(is_owner, 2);
@@ -530,7 +530,6 @@ module aptos_names::domain_e2e_tests {
         let (_, expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::none(), test_helper::domain_name());
         timestamp::update_global_time_for_test_secs(expiration_time_sec + 5);
 
-        // Is owner, but name has expired
         let (is_owner, _token_id) = domains::is_owner_of_name(user_addr, option::none(), test_helper::domain_name());
         assert!(!is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(user_addr, option::none(), test_helper::domain_name());

--- a/core/sources/domain_e2e_tests.move
+++ b/core/sources/domain_e2e_tests.move
@@ -12,7 +12,6 @@ module aptos_names::domain_e2e_tests {
     use std::signer;
     use std::string;
     use std::vector;
-    use aptos_names::test_helper::domain_name;
 
     #[test(myself = @aptos_names, user = @0x077, aptos = @0x1, rando = @0x266f, foundation = @0xf01d)]
     fun happy_path_e2e_test(myself: &signer, user: signer, aptos: signer, rando: signer, foundation: signer) {
@@ -273,7 +272,7 @@ module aptos_names::domain_e2e_tests {
             test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
             let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::none(), test_helper::domain_name());
             assert!(is_owner, 1);
-            let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::none(), domain_name());
+            let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::none(), test_helper::domain_name());
             assert!(is_owner, 1);
             assert!(!domains::name_is_expired(option::none(), test_helper::domain_name()), 1);
         };

--- a/core/sources/domains.move
+++ b/core/sources/domains.move
@@ -616,6 +616,8 @@ module aptos_names::domains {
         clear_reverse_lookup_for_name(subdomain_name, domain_name);
 
         let signer_addr = signer::address_of(sign);
+        let (is_owner, _) = is_owner_of_name(signer_addr, subdomain_name, domain_name);
+        assert!(is_owner, error::permission_denied(ENOT_OWNER_OF_NAME));
         let (is_owner, token_id) = is_token_owner(signer_addr, subdomain_name, domain_name);
         assert!(is_owner, error::permission_denied(ENOT_OWNER_OF_NAME));
         assert!(!name_is_expired(subdomain_name, domain_name), error::invalid_state(ENAME_EXPIRED));

--- a/core/sources/domains.move
+++ b/core/sources/domains.move
@@ -51,6 +51,10 @@ module aptos_names::domains {
     const EDOMAIN_TOO_SHORT: u64 = 17;
     /// Reverse lookup registry not initialized. `init_reverse_lookup_registry_v1` must be called first
     const EREVERSE_LOOKUP_NOT_INITIALIZED: u64 = 18;
+    /// Name has expired
+    const ENAME_EXPIRED: u64 = 19;
+    /// Cannot register a subdomain while its domain has expired
+    const ECANNOT_REGISTER_SUBDOMAIN_WHILE_DOMAIN_IS_EXPIRED: u64 = 20;
 
     struct NameRecordKeyV1 has copy, drop, store {
         subdomain_name: Option<String>,
@@ -248,8 +252,12 @@ module aptos_names::domains {
 
         // Ensure signer owns the domain we're registering a subdomain for
         let signer_addr = signer::address_of(sign);
-        let (is_owner, _token_id) = is_owner_of_name(signer_addr, option::none(), domain_name);
-        assert!(is_owner, error::permission_denied(ENOT_OWNER_OF_DOMAIN));
+        let (is_owner, _) = is_token_owner(signer_addr, option::some(subdomain_name), domain_name);
+        assert!(is_owner, error::permission_denied(ENOT_OWNER_OF_NAME));
+        assert!(
+            !name_is_expired(option::some(subdomain_name), domain_name),
+            error::invalid_state(ECANNOT_REGISTER_SUBDOMAIN_WHILE_DOMAIN_IS_EXPIRED)
+        );
 
         let registration_duration_secs = expiration_time_sec - timestamp::now_seconds();
 
@@ -486,6 +494,19 @@ module aptos_names::domains {
         }
     }
 
+    /// Returns true if the name is not registered OR (is registered AND is expired AND past grace period)
+    public fun name_is_expired_past_grace(subdomain_name: Option<String>, domain_name: String): bool acquires NameRegistryV1 {
+        if (!name_is_registered(subdomain_name, domain_name)) {
+            true
+        } else {
+            let aptos_names = borrow_global<NameRegistryV1>(@aptos_names);
+            let name_record_key = create_name_record_key_v1(subdomain_name, domain_name);
+            let name_record = table::borrow(&aptos_names.registry, name_record_key);
+            let (_property_version, expiration_time_sec, _target_address) = get_name_record_v1_props(name_record);
+            time_is_expired(expiration_time_sec + config::reregistration_grace_sec())
+        }
+    }
+
     /// Returns true if the name is registered
     /// If the name does not exist, returns false
     public fun name_is_registered(subdomain_name: Option<String>, domain_name: String): bool acquires NameRegistryV1 {
@@ -516,6 +537,25 @@ module aptos_names::domains {
         get_name_record_v1_props(table::borrow(&aptos_names.registry, name_record_key))
     }
 
+    /// Returns (true, token_id) if owner_address ownes the name otherwise (false, __)
+    /// Please use this one instead of is_owner_of_name
+    public fun is_token_owner(
+        owner_address: address,
+        subdomain_name: Option<String>,
+        domain_name: String
+    ): (bool, TokenId) {
+        let token_data_id = token_helper::build_tokendata_id(
+            token_helper::get_token_signer_address(),
+            subdomain_name,
+            domain_name
+        );
+        let token_id = token_helper::latest_token_id(&token_data_id);
+        (token::balance_of(owner_address, token_id) > 0, token_id)
+    }
+
+    /// !!!!! DEPRECATED !!!!! keep here for backward compatibility
+    /// Please use is_token_owner && name_is_expired or is_token_owner && name_is_expired_past_grace
+    ///
     /// Check if the address is the owner of the given aptos_name
     /// If the name does not exist or owner owns an expired name, returns false
     public fun is_owner_of_name(
@@ -576,8 +616,9 @@ module aptos_names::domains {
         clear_reverse_lookup_for_name(subdomain_name, domain_name);
 
         let signer_addr = signer::address_of(sign);
-        let (is_owner, token_id) = is_owner_of_name(signer_addr, subdomain_name, domain_name);
+        let (is_owner, token_id) = is_token_owner(signer_addr, subdomain_name, domain_name);
         assert!(is_owner, error::permission_denied(ENOT_OWNER_OF_NAME));
+        assert!(!name_is_expired(subdomain_name, domain_name), error::invalid_state(ENAME_EXPIRED));
 
         let name_record = set_name_address_internal(subdomain_name, domain_name, new_address);
         let (_property_version, expiration_time_sec, _target_address) = get_name_record_v1_props(&name_record);
@@ -660,7 +701,7 @@ module aptos_names::domains {
         };
 
         // Only the owner or the registered address can clear the address
-        let (is_owner, token_id) = is_owner_of_name(signer_addr, subdomain_name, domain_name);
+        let (is_owner, token_id) = is_token_owner(signer_addr, subdomain_name, domain_name);
         let is_name_resolved_address = name_resolved_address(subdomain_name, domain_name) == option::some<address>(
             signer_addr
         );
@@ -749,9 +790,9 @@ module aptos_names::domains {
     ) acquires NameRegistryV1, ReverseLookupRegistryV1, SetReverseLookupEventsV1 {
         let account_addr = signer::address_of(account);
         let (maybe_subdomain_name, domain_name) = get_name_record_key_v1_props(key);
-        let (is_owner, _) = is_owner_of_name(account_addr, maybe_subdomain_name, domain_name);
+        let (is_owner, _) = is_token_owner(account_addr, maybe_subdomain_name, domain_name);
         assert!(is_owner, error::permission_denied(ENOT_AUTHORIZED));
-
+        assert!(!name_is_expired(maybe_subdomain_name, domain_name), error::invalid_state(ENAME_EXPIRED));
         assert!(exists<ReverseLookupRegistryV1>(@aptos_names), error::invalid_state(EREVERSE_LOOKUP_NOT_INITIALIZED));
         let registry = &mut borrow_global_mut<ReverseLookupRegistryV1>(@aptos_names).registry;
         table::upsert(registry, account_addr, *key);

--- a/core/sources/domains.move
+++ b/core/sources/domains.move
@@ -706,7 +706,10 @@ module aptos_names::domains {
             signer_addr
         );
 
-        assert!(is_owner || is_name_resolved_address, error::permission_denied(ENOT_AUTHORIZED));
+        assert!(
+            (is_owner && !name_is_expired(subdomain_name, domain_name)) || is_name_resolved_address,
+            error::permission_denied(ENOT_AUTHORIZED)
+        );
 
         let name_record_key = create_name_record_key_v1(subdomain_name, domain_name);
         let aptos_names = borrow_global_mut<NameRegistryV1>(@aptos_names);

--- a/core/sources/domains.move
+++ b/core/sources/domains.move
@@ -252,10 +252,10 @@ module aptos_names::domains {
 
         // Ensure signer owns the domain we're registering a subdomain for
         let signer_addr = signer::address_of(sign);
-        let (is_owner, _) = is_token_owner(signer_addr, option::some(subdomain_name), domain_name);
+        let (is_owner, _) = is_token_owner(signer_addr, option::none(), domain_name);
         assert!(is_owner, error::permission_denied(ENOT_OWNER_OF_NAME));
         assert!(
-            !name_is_expired(option::some(subdomain_name), domain_name),
+            !name_is_expired(option::none(), domain_name),
             error::invalid_state(ECANNOT_REGISTER_SUBDOMAIN_WHILE_DOMAIN_IS_EXPIRED)
         );
 

--- a/core/sources/subdomain_e2e_tests.move
+++ b/core/sources/subdomain_e2e_tests.move
@@ -198,11 +198,13 @@ module aptos_names::subdomain_e2e_tests {
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::some(test_helper::subdomain_name()), test_helper::domain_name());
         assert!(is_owner, 1);
+        assert!(!domains::name_is_expired(option::some(test_helper::subdomain_name()), test_helper::domain_name()), 1);
 
         // Take the subdomain name for much longer than users are allowed to register it for
         domains::force_create_or_seize_name(myself, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs());
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(myself), option::some(test_helper::subdomain_name()), test_helper::domain_name());
         assert!(is_owner, 2);
+        assert!(!domains::name_is_expired(option::some(test_helper::subdomain_name()), test_helper::domain_name()), 2);
 
         // Ensure the expiration_time_sec is set to the new far future value
         let (_, expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::some(test_helper::subdomain_name()), test_helper::domain_name());
@@ -222,6 +224,7 @@ module aptos_names::subdomain_e2e_tests {
         domains::force_create_or_seize_name(myself, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs());
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(myself), option::some(test_helper::subdomain_name()), test_helper::domain_name());
         assert!(is_owner, 2);
+        assert!(!domains::name_is_expired(option::some(test_helper::subdomain_name()), test_helper::domain_name()), 2);
 
         // Ensure the expiration_time_sec is set to the new far future value
         let (_, expiration_time_sec, _) = domains::get_name_record_v1_props_for_name(option::some(test_helper::subdomain_name()), test_helper::domain_name());
@@ -301,6 +304,7 @@ module aptos_names::subdomain_e2e_tests {
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::some(test_helper::subdomain_name()), test_helper::domain_name());
         assert!(is_owner, 1);
+        assert!(!domains::name_is_expired(option::some(test_helper::subdomain_name()), test_helper::domain_name()), 1);
 
         // Attempt (and fail) to take the subdomain name for much longer than users are allowed to register it for
         domains::force_create_or_seize_name(rando, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::two_hundred_year_secs());

--- a/core/sources/subdomain_e2e_tests.move
+++ b/core/sources/subdomain_e2e_tests.move
@@ -196,12 +196,16 @@ module aptos_names::subdomain_e2e_tests {
         // Register the domain and subdomain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::some(test_helper::subdomain_name()), test_helper::domain_name());
+        assert!(is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::some(test_helper::subdomain_name()), test_helper::domain_name());
         assert!(is_owner, 1);
         assert!(!domains::name_is_expired(option::some(test_helper::subdomain_name()), test_helper::domain_name()), 1);
 
         // Take the subdomain name for much longer than users are allowed to register it for
         domains::force_create_or_seize_name(myself, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs());
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(myself), option::some(test_helper::subdomain_name()), test_helper::domain_name());
+        assert!(is_owner, 2);
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(myself), option::some(test_helper::subdomain_name()), test_helper::domain_name());
         assert!(is_owner, 2);
         assert!(!domains::name_is_expired(option::some(test_helper::subdomain_name()), test_helper::domain_name()), 2);
@@ -222,6 +226,8 @@ module aptos_names::subdomain_e2e_tests {
 
         // Take the subdomain name
         domains::force_create_or_seize_name(myself, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs());
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(myself), option::some(test_helper::subdomain_name()), test_helper::domain_name());
+        assert!(is_owner, 2);
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(myself), option::some(test_helper::subdomain_name()), test_helper::domain_name());
         assert!(is_owner, 2);
         assert!(!domains::name_is_expired(option::some(test_helper::subdomain_name()), test_helper::domain_name()), 2);
@@ -302,6 +308,8 @@ module aptos_names::subdomain_e2e_tests {
         // Register the domain and subdomain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::some(test_helper::subdomain_name()), test_helper::domain_name());
+        assert!(is_owner, 1);
         let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::some(test_helper::subdomain_name()), test_helper::domain_name());
         assert!(is_owner, 1);
         assert!(!domains::name_is_expired(option::some(test_helper::subdomain_name()), test_helper::domain_name()), 1);

--- a/core/sources/subdomain_e2e_tests.move
+++ b/core/sources/subdomain_e2e_tests.move
@@ -196,12 +196,12 @@ module aptos_names::subdomain_e2e_tests {
         // Register the domain and subdomain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::some(test_helper::subdomain_name()), test_helper::domain_name());
+        let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::some(test_helper::subdomain_name()), test_helper::domain_name());
         assert!(is_owner, 1);
 
         // Take the subdomain name for much longer than users are allowed to register it for
         domains::force_create_or_seize_name(myself, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs());
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(myself), option::some(test_helper::subdomain_name()), test_helper::domain_name());
+        let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(myself), option::some(test_helper::subdomain_name()), test_helper::domain_name());
         assert!(is_owner, 2);
 
         // Ensure the expiration_time_sec is set to the new far future value
@@ -220,7 +220,7 @@ module aptos_names::subdomain_e2e_tests {
 
         // Take the subdomain name
         domains::force_create_or_seize_name(myself, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs());
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(myself), option::some(test_helper::subdomain_name()), test_helper::domain_name());
+        let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(myself), option::some(test_helper::subdomain_name()), test_helper::domain_name());
         assert!(is_owner, 2);
 
         // Ensure the expiration_time_sec is set to the new far future value
@@ -299,7 +299,7 @@ module aptos_names::subdomain_e2e_tests {
         // Register the domain and subdomain
         test_helper::register_name(user, option::none(), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_domain_name(), 1, vector::empty<u8>());
         test_helper::register_name(user, option::some(test_helper::subdomain_name()), test_helper::domain_name(), test_helper::one_year_secs(), test_helper::fq_subdomain_name(), 1, vector::empty<u8>());
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), option::some(test_helper::subdomain_name()), test_helper::domain_name());
+        let (is_owner, _token_id) = domains::is_token_owner(signer::address_of(user), option::some(test_helper::subdomain_name()), test_helper::domain_name());
         assert!(is_owner, 1);
 
         // Attempt (and fail) to take the subdomain name for much longer than users are allowed to register it for

--- a/core/sources/test_helper.move
+++ b/core/sources/test_helper.move
@@ -104,6 +104,8 @@ module aptos_names::test_helper {
         let (tdi_creator, tdi_collection, tdi_name, tdi_property_version) = token::get_token_id_fields(&token_id);
 
         assert!(is_owner, 3);
+        assert!(!domains::name_is_expired(subdomain_name, domain_name), 3);
+
         assert!(tdi_creator == token_helper::get_token_signer_address(), 4);
         assert!(tdi_collection == config::collection_name_v1(), 5);
         test_utils::print_actual_expected(b"tdi_name: ", tdi_name, expected_fq_domain_name, false);

--- a/core/sources/test_helper.move
+++ b/core/sources/test_helper.move
@@ -100,7 +100,7 @@ module aptos_names::test_helper {
         assert!(!domains::name_is_registerable(subdomain_name, domain_name), 13);
         assert!(domains::name_is_registered(subdomain_name, domain_name), 14);
 
-        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), subdomain_name, domain_name);
+        let (is_owner, token_id) = domains::is_owner_of_name(user_addr, subdomain_name, domain_name);
         assert!(is_owner, 3);
         let (is_owner, token_id) = domains::is_token_owner(user_addr, subdomain_name, domain_name);
         let (tdi_creator, tdi_collection, tdi_name, tdi_property_version) = token::get_token_id_fields(&token_id);

--- a/core/sources/test_helper.move
+++ b/core/sources/test_helper.move
@@ -100,6 +100,8 @@ module aptos_names::test_helper {
         assert!(!domains::name_is_registerable(subdomain_name, domain_name), 13);
         assert!(domains::name_is_registered(subdomain_name, domain_name), 14);
 
+        let (is_owner, _token_id) = domains::is_owner_of_name(signer::address_of(user), subdomain_name, domain_name);
+        assert!(is_owner, 3);
         let (is_owner, token_id) = domains::is_token_owner(user_addr, subdomain_name, domain_name);
         let (tdi_creator, tdi_collection, tdi_name, tdi_property_version) = token::get_token_id_fields(&token_id);
 

--- a/core/sources/test_helper.move
+++ b/core/sources/test_helper.move
@@ -100,7 +100,7 @@ module aptos_names::test_helper {
         assert!(!domains::name_is_registerable(subdomain_name, domain_name), 13);
         assert!(domains::name_is_registered(subdomain_name, domain_name), 14);
 
-        let (is_owner, token_id) = domains::is_owner_of_name(user_addr, subdomain_name, domain_name);
+        let (is_owner, token_id) = domains::is_token_owner(user_addr, subdomain_name, domain_name);
         let (tdi_creator, tdi_collection, tdi_name, tdi_property_version) = token::get_token_id_fields(&token_id);
 
         assert!(is_owner, 3);

--- a/core/sources/test_helper.move
+++ b/core/sources/test_helper.move
@@ -100,7 +100,7 @@ module aptos_names::test_helper {
         assert!(!domains::name_is_registerable(subdomain_name, domain_name), 13);
         assert!(domains::name_is_registered(subdomain_name, domain_name), 14);
 
-        let (is_owner, token_id) = domains::is_owner_of_name(user_addr, subdomain_name, domain_name);
+        let (is_owner, _) = domains::is_owner_of_name(user_addr, subdomain_name, domain_name);
         assert!(is_owner, 3);
         let (is_owner, token_id) = domains::is_token_owner(user_addr, subdomain_name, domain_name);
         let (tdi_creator, tdi_collection, tdi_name, tdi_property_version) = token::get_token_id_fields(&token_id);

--- a/router/sources/primary_name_tests.move
+++ b/router/sources/primary_name_tests.move
@@ -316,7 +316,7 @@ module router::primary_name_tests {
         router::clear_primary_name(user);
         {
             // domain should be successfully migrated to v2
-            let (is_owner_of_v1_name, _) = aptos_names::domains::is_owner_of_name(user_addr, option::none(), domain_name);
+            let (is_owner_of_v1_name, _) = aptos_names::domains::is_token_owner(user_addr, option::none(), domain_name);
             assert!(!is_owner_of_v1_name, 1);
             assert!(aptos_names_v2::v2_domains::is_owner_of_name(user_addr, option::none(), domain_name), 2);
             // v1 primary name should be cleared
@@ -380,7 +380,7 @@ module router::primary_name_tests {
         router::clear_primary_name(user);
         {
             // subdomain should still remain in v1
-            let (is_owner_of_v1_name, _) = aptos_names::domains::is_owner_of_name(user_addr, subdomain_name_opt, domain_name);
+            let (is_owner_of_v1_name, _) = aptos_names::domains::is_token_owner(user_addr, subdomain_name_opt, domain_name);
             assert!(is_owner_of_v1_name, 1);
             assert!(!aptos_names_v2::v2_domains::is_owner_of_name(user_addr, subdomain_name_opt, domain_name), 2);
             // v1 primary name should be cleared

--- a/router/sources/primary_name_tests.move
+++ b/router/sources/primary_name_tests.move
@@ -381,6 +381,7 @@ module router::primary_name_tests {
         {
             // subdomain should still remain in v1
             let (is_owner_of_v1_name, _) = aptos_names::domains::is_token_owner(user_addr, subdomain_name_opt, domain_name);
+            assert!(!aptos_names::domains::name_is_expired(subdomain_name_opt, domain_name), 1);
             assert!(is_owner_of_v1_name, 1);
             assert!(!aptos_names_v2::v2_domains::is_owner_of_name(user_addr, subdomain_name_opt, domain_name), 2);
             // v1 primary name should be cleared

--- a/router/sources/renewal_domain_tests.move
+++ b/router/sources/renewal_domain_tests.move
@@ -134,7 +134,7 @@ module router::renewal_domain_tests {
         // Domain should be auto migrated to v2 and renewed with 1 year
         {
             // v1 name should be burnt now, i.e. not owned by the user now
-            let (is_v1_owner, _) = aptos_names::domains::is_owner_of_name(user_addr, option::none(), domain_name);
+            let (is_v1_owner, _) = aptos_names::domains::is_token_owner(user_addr, option::none(), domain_name);
             assert!(!is_v1_owner, 1);
             // v2 name should be owned by user
             assert!(aptos_names_v2::v2_domains::is_owner_of_name(user_addr, option::none(), domain_name), 2);

--- a/router/sources/router.move
+++ b/router/sources/router.move
@@ -153,12 +153,12 @@ module router::router {
             subdomain_name,
             domain_name
         ) && !domains::name_is_expired(subdomain_name, domain_name)) {
-            let (is_owner, _token_id) = domains::is_token_owner(
+            let (is_burned, _token_id) = domains::is_token_owner(
                 router_signer_addr(),
                 subdomain_name,
                 domain_name
             );
-            is_owner && !domains::name_is_expired(subdomain_name, domain_name)
+            is_burned
         } else {
             v2_domains::is_name_registerable(domain_name, subdomain_name)
         }


### PR DESCRIPTION
 use `is_token_owner` and `is_name_expired` along side `is_owner_of_name` so we can phase out `is_owner_of_name` in the future