### PR TITLE
Reset subdomains on domain re-registration

### DIFF
--- a/core_v2/sources/v2_test_helper.move
+++ b/core_v2/sources/v2_test_helper.move
@@ -93,7 +93,7 @@ module aptos_names_v2::v2_test_helper {
                 user,
                 domain_name,
                 *option::borrow(&subdomain_name),
-                registration_duration_secs
+                timestamp::now_seconds() + registration_duration_secs
             );
         };
 


### PR DESCRIPTION
 - Add `registration_time_sec` that gets assigned to current time during registration
 - Add `is_subdomain_registered_before_domain`. This gets used when checking if a name [subdomain] has expired. `is_name_registerable` relies on `is_name_expired` so this also gets accounted for
 - Add test to ensure subdomains can be re-registered if the domain gets re-registered
 - Fix `v2_test_helper::register_name` to use `registration_duration_secs` as opposed to `expiration_time_sec` for subdomains (requires changes to usages of `register_name` on subdomains`