### PR TITLE
Update unit test to check primary name is always cleared in v1 after set in v2

### DIFF
--- a/router/sources/tests/primary_name_tests.move
+++ b/router/sources/tests/primary_name_tests.move
@@ -86,6 +86,9 @@ module router::primary_name_tests {
         let (primary_subdomain_name, primary_domain_name) = router::get_primary_name(user_addr);
         assert!(*option::borrow(&primary_domain_name) == domain_name, 1);
         assert!(option::is_none(&primary_subdomain_name), 2);
+
+        // v1 primary name is cleared
+        assert!(option::is_none(&aptos_names::domains::get_reverse_lookup(address_of(user))), 14);
     }
 
     #[test(

--- a/router/sources/tests/registration_tests.move
+++ b/router/sources/tests/registration_tests.move
@@ -48,6 +48,13 @@ module router::registration_tests {
         router::register_domain(user, domain_name2, SECONDS_PER_YEAR, option::none(), option::none());
         assert!(router::is_name_owner(user_addr, domain_name1, option::none()), 2);
         assert!(router::is_name_owner(user_addr, domain_name2, option::none()), 3);
+
+        // v1 primary name is cleared
+        assert!(option::is_none(&aptos_names::domains::get_reverse_lookup(address_of(user))), 4);
+        // v2 primary name is properly set
+        let (primary_subdomain_name, primary_domain_name) = router::router::get_primary_name(address_of(user));
+        assert!(option::is_none(&primary_subdomain_name), 5);
+        assert!(option::some(domain_name2) == primary_domain_name, 6);
     }
 
     #[test(

--- a/router/sources/tests/target_address_tests.move
+++ b/router/sources/tests/target_address_tests.move
@@ -161,6 +161,9 @@ module router::target_address_tests {
             let target_address = get_v2_target_addr(domain_name, subdomain_name_opt);
             assert!(option::is_none(&target_address), 6);
         };
+
+        // v1 primary name is cleared
+        assert!(option::is_none(&aptos_names::domains::get_reverse_lookup(user_addr)), 7);
     }
 
     #[test(


### PR DESCRIPTION
Whenever primary name is set in v2, it should be cleared in v1 because of [this line](https://github.com/aptos-labs/aptos-names-contracts/blob/bl/rew/router/sources/router.move#L522), adding unit test to make sure of that