### PR TITLE
[ans] add script for bulk renewal

### DIFF
--- a/bulk_force_renewal/Move.toml
+++ b/bulk_force_renewal/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = 'aptos_names_bulk_force_renewal'
+version = '1.0.0'
+
+[addresses]
+repository = "_"
+
+[dependencies.aptos_names_v2_1]
+local = "../core_v2"

--- a/bulk_force_renewal/README.md
+++ b/bulk_force_renewal/README.md
@@ -1,0 +1,11 @@
+This script helps with bulk name renewal as an admin. It will overrule the renewal window and the max renewal period.  
+
+Preparation:
+1. Update `Move.toml` with the correct `repository` account.
+2. Use the admin account to run the script.
+
+Each iteration:
+1. Update the script with the appropriate names to renew 
+2. Update the time period to renew the names for
+3. Compile the script: `aptos move compile`
+4. Run the script: `aptos move run-script --compiled-script-path bulk_force_renewal/build/aptos_names_bulk_force_renewal/bytecode_scripts/main.mv --profile admin`

--- a/bulk_force_renewal/sources/script.move
+++ b/bulk_force_renewal/sources/script.move
@@ -1,0 +1,24 @@
+script {
+    use std::option;
+    use aptos_framework::timestamp;
+
+    const SECONDS_PER_YEAR: u64 = 60 * 60 * 24 * 365;
+
+    fun main(admin: &signer) {
+        let names = vector [
+            b"name01",
+            b"name02",
+        ];
+        let years_to_expire = 100;
+
+        while (!std::vector::is_empty(&names)) {
+            let name = std::string::utf8(std::vector::pop_back(&mut names));
+            aptos_names_v2_1::v2_1_domains::force_set_name_expiration(
+                admin,
+                name,
+                option::none(),
+                timestamp::now_seconds() + SECONDS_PER_YEAR * years_to_expire,
+            )
+        }
+    }
+}


### PR DESCRIPTION
### goal
we want to migrate a series of reserved names from v1 to v2, then extend their expiration to forever. 

### plan
- run a script/execute function to migrate names from v2 to v1 on behalf of the owner
- run this script to extend the expiration on behalf of admin