### PR TITLE
[deps] Use the mainnet framework everywhere

### DIFF
--- a/core/Move.toml
+++ b/core/Move.toml
@@ -10,10 +10,10 @@ router_signer = "_"
 
 [dependencies.AptosFramework]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'framework-mainnet'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-framework'
 
 [dependencies.AptosToken]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'framework-mainnet'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-token'

--- a/core_v2/Move.toml
+++ b/core_v2/Move.toml
@@ -10,15 +10,15 @@ aptos_names_funds = "_"
 
 [dependencies.AptosFramework]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-framework'
 
 [dependencies.AptosToken]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-token'
 
 [dependencies.AptosTokenObjects]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-token-objects'

--- a/distribute/Move.toml
+++ b/distribute/Move.toml
@@ -7,5 +7,5 @@ local = "../core"
 
 [dependencies.AptosToken]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-token'

--- a/router/Move.toml
+++ b/router/Move.toml
@@ -10,15 +10,15 @@ local = "../core_v2"
 
 [dependencies.AptosFramework]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-framework'
 
 [dependencies.AptosToken]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-token'
 
 [dependencies.AptosTokenObjects]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-token-objects'


### PR DESCRIPTION
The contracts were published with different versions of the framework, that all merged together funny.  Now, it will get published with the same version across all of them.