### PR TITLE
Redundant/Inaccessible check in `set_domain_price_for_length`

### DIFF
--- a/core_v2/sources/v2_1_config.move
+++ b/core_v2/sources/v2_1_config.move
@@ -223,7 +223,6 @@ module aptos_names_v2_1::v2_1_config {
     public entry fun set_domain_price_for_length(sign: &signer, price: u64, length: u64) acquires Config {
         assert_signer_is_admin(sign);
         assert!(length >= 3, error::invalid_argument(EINVALID_DOMAIN_LENGTH));
-        assert!(length >= 3, length);
         if (length == 3) {
             borrow_global_mut<Config>(@aptos_names_v2_1).domain_price_length_3 = price
         } else if (length == 4) {


### PR DESCRIPTION
According to the implementation of `set_domain_price_for_length` function, there is a redundant check:
```move
        assert!(length >= 3, error::invalid_argument(EINVALID_DOMAIN_LENGTH));
        assert!(length >= 3, length); //@note 
```
The second validation is covered by the first one and also provides an invalid error code.

Location:  https://github.com/aptos-labs/aptos-names-contracts/blob/main/core_v2/sources/v2_1_config.move#L226
