### PR TITLE
ci: security hardening

### DIFF
--- a/.github/workflows/move_tests.yaml
+++ b/.github/workflows/move_tests.yaml
@@ -7,6 +7,9 @@ on:
       - testnet
       - mainnet
 
+permissions:
+  contents: read
+
 jobs:
   move-tests:
     runs-on: ubuntu-latest
@@ -14,6 +17,8 @@ jobs:
       - name: Install Aptos CLI
         run: curl -fsSL "https://aptos.dev/scripts/install_cli.py" | python3
         shell: bash
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Runs move tests.
         run: ./sh_scripts/move_tests.sh


### PR DESCRIPTION
## Summary

This PR hardens the GitHub Actions CI configuration for `.github/workflows/move_tests.yaml` based on a `zizmor` security audit (v1.24.1).

## Fixes Applied

### 1. SHA-pin `actions/checkout`
- **Before:** `actions/checkout@v4` (mutable floating tag)
- **After:** `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2`
- Pinning to a specific commit SHA prevents supply-chain attacks where a tag is silently moved to a malicious commit.
- Verified v4.2.2 is the latest stable v4.x release and not deprecated.

### 2. Add `persist-credentials: false` to checkout
- Prevents the GitHub token from being persisted into the local `.git/config`, reducing the blast radius if the job is compromised or if build artifacts (workspace files) are inadvertently uploaded.
- Safe to apply here because the `move-tests` job does not perform any `git push` or `git commit` operations after checkout.

### 3. Add least-privilege `permissions` block
- Added `permissions: contents: read` at the workflow level.
- The `move-tests` job only needs to read repository contents to run tests — it does not write to git, upload releases, or use OIDC. The default GitHub Actions permissions are overly broad (write access to most scopes when using a PAT-style token context).

## Zizmor Results

| Before | After |
|--------|-------|
| `unpinned-uses` (HIGH) on `actions/checkout@v4` | ✅ Fixed |
| `artipacked` (MEDIUM) — no `persist-credentials: false` | ✅ Fixed |
| `excessive-permissions` (MEDIUM) — no permissions block | ✅ Fixed |

Re-running `zizmor .github/` after this patch returns **0 findings**.

## Intentional Non-Fixes

- **No `aptos-labs/*` actions are present** in this repo currently, so the policy of not SHA-pinning internal actions has no applicable instances here.
- **No `artipacked` exemptions needed** — the checkout step was not legitimately writing back to git.